### PR TITLE
Fixed variable name type (ax_prog_javah_bin_dir) and follow javah symlin...

### DIFF
--- a/m4/ax_prog_javah.m4
+++ b/m4/ax_prog_javah.m4
@@ -21,7 +21,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_PROG_JAVAH], [AX_PROG_JAVAH])
 AC_DEFUN([AX_PROG_JAVAH],[
@@ -32,8 +32,9 @@ AS_IF([test -n "$ac_cv_path_JAVAH"],
       [
         AC_TRY_CPP([#include <jni.h>],,[
         ac_save_CPPFLAGS="$CPPFLAGS"
-        ax_prog_javah_bin_dir=`AS_DIRNAME([$ac_cv_path_JAVAH])`
-        ac_dir="`AS_DIRNAME([$ax_prog_javah_bin])`/include"
+		_ACJAVAH_FOLLOW_SYMLINKS("$ac_cv_path_JAVAH")
+        ax_prog_javah_bin_dir=`AS_DIRNAME([$_ACJAVAH_FOLLOWED])`
+        ac_dir="`AS_DIRNAME([$ax_prog_javah_bin_dir])`/include"
         AS_CASE([$build_os],
                 [cygwin*],
                 [ac_machdep=win32],
@@ -44,4 +45,20 @@ AS_IF([test -n "$ac_cv_path_JAVAH"],
                    AC_MSG_WARN([unable to include <jni.h>]))
         CPPFLAGS="$ac_save_CPPFLAGS"])
       ])
+])
+
+AC_DEFUN([_ACJAVAH_FOLLOW_SYMLINKS],[
+# find the include directory relative to the javac executable
+_cur="$1"
+while ls -ld "$_cur" 2>/dev/null | grep " -> " >/dev/null; do
+        AC_MSG_CHECKING([symlink for $_cur])
+        _slink=`ls -ld "$_cur" | sed 's/.* -> //'`
+        case "$_slink" in
+        /*) _cur="$_slink";;
+        # 'X' avoids triggering unwanted echo options.
+        *) _cur=`echo "X$_cur" | sed -e 's/^X//' -e 's:[[^/]]*$::'`"$_slink";;
+        esac
+        AC_MSG_RESULT([$_cur])
+done
+_ACJAVAH_FOLLOWED="$_cur"
 ])


### PR DESCRIPTION
Fixed variable name type ('ax_prog_javah_bin_dir' was 'ax_prog_javah_bin') and follow javah symlink to java installation folder to find jni.h.

On my system javah is actually /usr/bin/javah, which is a symlink.  So it wouldn't find javah/../../include.
