### PR TITLE
Support standard Oracle JDK installation layout on Mac OS X.

### DIFF
--- a/m4/ax_jni_include_dir.m4
+++ b/m4/ax_jni_include_dir.m4
@@ -44,7 +44,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 10
+#serial 11
 
 AU_ALIAS([AC_JNI_INCLUDE_DIR], [AX_JNI_INCLUDE_DIR])
 AC_DEFUN([AX_JNI_INCLUDE_DIR],[
@@ -66,8 +66,13 @@ else
 fi
 
 case "$host_os" in
-        darwin*)        _JTOPDIR=`echo "$_JTOPDIR" | sed -e 's:/[[^/]]*$::'`
-                        _JINC="$_JTOPDIR/Headers";;
+        darwin*)        # Apple JDK is at /System location and has headers symlinked elsewhere
+                        case "$_JTOPDIR" in
+                        /System/Library/Frameworks/JavaVM.framework/*)
+				_JTOPDIR=`echo "$_JTOPDIR" | sed -e 's:/[[^/]]*$::'`
+				_JINC="$_JTOPDIR/Headers";;
+			*)      _JINC="$_JTOPDIR/include";;
+                        esac;;
         *)              _JINC="$_JTOPDIR/include";;
 esac
 _AS_ECHO_LOG([_JTOPDIR=$_JTOPDIR])
@@ -88,6 +93,7 @@ AC_CHECK_FILE([$_JINC/jni.h],
 case "$host_os" in
 bsdi*)          _JNI_INC_SUBDIRS="bsdos";;
 freebsd*)       _JNI_INC_SUBDIRS="freebsd";;
+darwin*)        _JNI_INC_SUBDIRS="darwin";;
 linux*)         _JNI_INC_SUBDIRS="linux genunix";;
 osf*)           _JNI_INC_SUBDIRS="alpha";;
 solaris*)       _JNI_INC_SUBDIRS="solaris";;


### PR DESCRIPTION
Hello,

I tried to use AX_JNI_INCLUDE_DIR in Mac OS X and failed. Reading the implementation, I found that it basically assumes that JDK 6 is being used, as packaged by Apple. Apple's packaging differs from others, in that headers are NOT placed in $JAVA_HOME/include and so it fails to locate them on my OS X Yosemite machine with Oracle JDK 8 installed (also tried Oracle JDK 7 and got the same failure).

Since JDK 7 this is no longer the case on OS X, as Apple no longer provides its own packages (most users install Oracle's JDK). Therefore AX_JNI_INCLUDE_DIR fails to locate the headers (which are now in the "standard" $JAVA_HOME/include location and the special-handling code for "darwin" fails to find them).

This patch adjust the "darwin" special-case handling as follows: it checks to see if the detected JDK is located in /System/Library/Frameworks/JavaVM.framework (this is where Apple installs its package) and only uses the special-handling for that case. Otherwise it reverts to "default handling" as for all other platforms. This is the only way I could think of to "reliably" determine if we are talking about packaging (Apple reserves /System/Library for its own packages).

IMPORTANT: I am not an M4 expert, have never contributed to autoconf-archive and the patch is a best-effort attempt to provide implementation for something that I feel was "too trivial to submit a feature request for without feeling embarrassed". Please feel free to implement from scratch and consider this an "informed request".
