### PR TITLE
AX_VALGRIND_CHECK: Add a macro to enable Valgrind on `make check`

### DIFF
--- a/m4/ax_valgrind_check.m4
+++ b/m4/ax_valgrind_check.m4
@@ -1,0 +1,166 @@
+# ===========================================================================
+#     http://www.gnu.org/software/autoconf-archive/ax_valgrind_check.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_VALGRIND_CHECK()
+#
+# DESCRIPTION
+#
+#   Checks whether Valgrind is present and, if so, allows running `make check`
+#   under a variety of Valgrind tools to check for memory and threading errors.
+#
+#   Defines VALGRIND_CHECK_RULES which should be substituted in your Makefile;
+#   and $enable_valgrind which can be used in subsequent configure output.
+#   VALGRIND_ENABLED is defined and substituted, and corresponds to the value
+#   of the --enable-valgrind option, which defaults to being enabled if
+#   Valgrind is installed and disabled otherwise.
+#
+#   If unit tests are written using a shell script and automake's LOG_COMPILER
+#   system, the $(VALGRIND) variable can be used within the shell scripts to
+#   enable Valgrind, as described here:
+#
+#       https://www.gnu.org/software/gnulib/manual/html_node/Running-self_002dtests-under-valgrind.html
+#
+#   Usage example:
+#
+#   configure.ac:
+#
+#     AX_VALGRIND_CHECK
+#
+#   Makefile.am:
+#
+#     @VALGRIND_CHECK_RULES@
+#     VALGRIND_SUPPRESSIONS_FILES = my-project.supp
+#     EXTRA_DIST = my-project.supp
+#
+#   This results in a "check-valgrind" rule being added to any Makefile.am
+#   which includes "@VALGRIND_CHECK_RULES@" (assuming the module has been
+#   configured with --enable-valgrind). Running `make check-valgrind` in that
+#   directory will run the module's test suite (`make check`) once for each of
+#   the available Valgrind tools (out of memcheck, helgrind, drd and sgcheck),
+#   and will output results to test-suite-$toolname.log for each. The target
+#   will succeed if there are zero errors and fail otherwise.
+#
+# LICENSE
+#
+#   Copyright (c) 2014 Philip Withnall <philip.withnall@collabora.co.uk>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 1
+
+AC_DEFUN([AX_VALGRIND_CHECK],[
+	dnl Check for --enable-valgrind
+	AC_MSG_CHECKING([whether to enable Valgrind on the unit tests])
+	AC_ARG_ENABLE([valgrind],
+	              [AS_HELP_STRING([--enable-valgrind], [Whether to enable Valgrind on the unit tests])],
+	              [enable_valgrind=$enableval],[enable_valgrind=])
+
+	# Check for Valgrind.
+	AC_CHECK_PROG([VALGRIND],[valgrind],[valgrind])
+
+	AS_IF([test "$enable_valgrind" = "yes" -a "$VALGRIND" = ""],[
+		AC_MSG_ERROR([Could not find valgrind; either install it or reconfigure with --disable-valgrind])
+	])
+	AS_IF([test "$enable_valgrind" != "no"],[enable_valgrind=yes])
+
+	AM_CONDITIONAL([VALGRIND_ENABLED],[test "$enable_valgrind" = "yes"])
+	AC_SUBST([VALGRIND_ENABLED],[$enable_valgrind])
+	AC_MSG_RESULT([$enable_valgrind])
+
+	# Check for Valgrind tools we care about.
+	m4_define([valgrind_tool_list],[[memcheck], [helgrind], [drd], [exp-sgcheck]])
+
+	AS_IF([test "$VALGRIND" != ""],[
+		m4_foreach([vgtool],[valgrind_tool_list],[
+			m4_define([vgtooln],AS_TR_SH(vgtool))
+			m4_define([ax_cv_var],[ax_cv_valgrind_tool_]vgtooln)
+			AC_CACHE_CHECK([for Valgrind tool ]vgtool,ax_cv_var,[
+				ax_cv_var=
+				AS_IF([`$VALGRIND --tool=vgtool --help 2&>/dev/null`],[
+					ax_cv_var="vgtool"
+				])
+			])
+
+			AC_SUBST([VALGRIND_HAVE_TOOL_]vgtooln,[$ax_cv_var])
+		])
+	])
+
+VALGRIND_CHECK_RULES='
+# Valgrind check
+#
+# Optional:
+#  - VALGRIND_SUPPRESSIONS_FILES: Space-separated list of Valgrind suppressions
+#    files to load. (Default: empty)
+#  - VALGRIND_FLAGS: General flags to pass to all Valgrind tools.
+#    (Default: --num-callers=30)
+#  - VALGRIND_$toolname_FLAGS: Flags to pass to Valgrind $toolname (one of:
+#    memcheck, helgrind, drd, sgcheck). (Default: various)
+
+# Optional variables
+VALGRIND_SUPPRESSIONS ?= $(addprefix --suppressions=,$(VALGRIND_SUPPRESSIONS_FILES))
+VALGRIND_FLAGS ?= --num-callers=30
+VALGRIND_memcheck_FLAGS ?= --leak-check=full --show-reachable=no
+VALGRIND_helgrind_FLAGS ?= --history-level=approx
+VALGRIND_drd_FLAGS ?=
+VALGRIND_sgcheck_FLAGS ?=
+
+valgrind_quiet = $(valgrind_quiet_$(V))
+valgrind_quiet_ = $(valgrind_quiet_$(AM_DEFAULT_VERBOSITY))
+valgrind_quiet_0 = --quiet
+
+# Use recursive makes in order to ignore errors during check
+check-valgrind:
+ifeq ($(VALGRIND_ENABLED),yes)
+ifneq ($(VALGRIND_HAVE_TOOL_memcheck),)
+	-$(MAKE) $(AM_MAKEFLAGS) -k check-valgrind-tool VALGRIND_TOOL=memcheck
+endif
+ifneq ($(VALGRIND_HAVE_TOOL_helgrind),)
+	-$(MAKE) $(AM_MAKEFLAGS) -k check-valgrind-tool VALGRIND_TOOL=helgrind
+endif
+ifneq ($(VALGRIND_HAVE_TOOL_drd),)
+	-$(MAKE) $(AM_MAKEFLAGS) -k check-valgrind-tool VALGRIND_TOOL=drd
+endif
+ifneq ($(VALGRIND_HAVE_TOOL_sgcheck),)
+	-$(MAKE) $(AM_MAKEFLAGS) -k check-valgrind-tool VALGRIND_TOOL=sgcheck
+endif
+else
+	@echo "Need to reconfigure with --enable-valgrind"
+endif
+
+# Valgrind running
+VALGRIND_TESTS_ENVIRONMENT = \
+	$(TESTS_ENVIRONMENT) \
+	env VALGRIND=$(VALGRIND) \
+	G_SLICE=always-malloc,debug-blocks \
+	G_DEBUG=fatal-warnings,fatal-criticals,gc-friendly
+
+VALGRIND_LOG_COMPILER = \
+	$(LIBTOOL) $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=execute \
+	$(VALGRIND) $(VALGRIND_SUPPRESSIONS) --error-exitcode=1 $(VALGRIND_FLAGS)
+
+check-valgrind-tool:
+ifeq ($(VALGRIND_ENABLED),yes)
+	$(MAKE) check-TESTS \
+		TESTS_ENVIRONMENT="$(VALGRIND_TESTS_ENVIRONMENT)" \
+		LOG_COMPILER="$(VALGRIND_LOG_COMPILER)" \
+		LOG_FLAGS="--tool=$(VALGRIND_TOOL) $(VALGRIND_$(VALGRIND_TOOL)_FLAGS)" \
+		TEST_SUITE_LOG=test-suite-$(VALGRIND_TOOL).log
+else
+	@echo "Need to reconfigure with --enable-valgrind"
+endif
+
+DISTCHECK_CONFIGURE_FLAGS ?=
+DISTCHECK_CONFIGURE_FLAGS += --disable-valgrind
+
+.PHONY: check-valgrind check-valgrind-tool
+'
+
+	AC_SUBST([VALGRIND_CHECK_RULES])
+	m4_ifdef([_AM_SUBST_NOTMAKE], [_AM_SUBST_NOTMAKE([VALGRIND_CHECK_RULES])])
+])


### PR DESCRIPTION
See the documentation in the macro file for a full description.
