### PR TITLE
bootstrap.sh: Do a shallow clone of gnulib

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,7 +3,7 @@
 set -eu
 
 if [ ! -d "gnulib" ] && [ $# -gt 0 ] && [ "$1" = "--copy" ]; then
-  git clone git://git.savannah.gnu.org/gnulib.git gnulib
+  git clone --depth 1 git://git.savannah.gnu.org/gnulib.git gnulib
 fi
 
 if [ -x "gnulib/gnulib-tool" ]; then


### PR DESCRIPTION
We just need some utilities from gnulib, so getting an entire history
of changes of the library is pointless. And it also takes more time.