### PR TITLE
ax_lib_postgresql: Double-quote the literal with square brackets

### DIFF
--- a/m4/ax_lib_postgresql.m4
+++ b/m4/ax_lib_postgresql.m4
@@ -211,11 +211,11 @@ AC_DEFUN([AX_LIB_POSTGRESQL],
 		  [
 		   #include <libpq-fe.h>
 		  ],
-		  [
+		  [[
 		    char conninfo[]="dbname = postgres";
 		    PGconn     *conn;
 		    conn = PQconnectdb(conninfo);
-		  ]
+		  ]]
 		 )
 		],[ac_cv_postgresql_found=yes],
 		  [ac_cv_postgresql_found=no])


### PR DESCRIPTION
Unescaped square brackets get lost after autoconf, so you get
char conninfo="dbname = postgres";
in the configure script and the following errors in config.log when running ./configure:
```
...
conftest.cpp:30:21: error: invalid conversion from 'const char*' to 'char' [-fpermissive]
       char conninfo="dbname = postgres";
                     ^~~~~~~~~~~~~~~~~~~
conftest.cpp:32:34: error: invalid conversion from 'char' to 'const char*' [-fpermissive]
       conn = PQconnectdb(conninfo);
                                  ^
In file included from conftest.cpp:24:0:
/usr/lib/pgsql/include/libpq-fe.h:268:16: note:   initializing argument 1 of 'PGconn* PQconnectdb(const char*)'
 extern PGconn *PQconnectdb(const char *conninfo);
                ^~~~~~~~~~~
configure:4749: $? = 1
configure: failed program was:
...

configure:4754: error: could not find libpq-fe.h header
```
