### PR TITLE
Replace obsolete AC_TRY_RUN with AC_RUN_IFELSE

### DIFF
--- a/m4/ax_check_allocated_ctime.m4
+++ b/m4/ax_check_allocated_ctime.m4
@@ -19,18 +19,18 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AG_CHECK_ALLOCATED_CTIME], [AX_CHECK_ALLOCATED_CTIME])
 AC_DEFUN([AX_CHECK_ALLOCATED_CTIME],[
   AC_MSG_CHECKING([whether ctime() allocates memory for its result])
   AC_CACHE_VAL([ax_cv_allocated_ctime],[
-  AC_TRY_RUN([#include <time.h>
+  AC_RUN_IFELSE([AC_LANG_SOURCE([[#include <time.h>
 int main (int argc, char** argv) {
    time_t  timeVal = time( (time_t*)NULL );
    char*   pzTime  = ctime( &timeVal );
    free( pzTime );
-   return 0; }],[ax_cv_allocated_ctime=yes],[ax_cv_allocated_ctime=no],[ax_cv_allocated_ctime=no]
+   return 0; }]])],[ax_cv_allocated_ctime=yes],[ax_cv_allocated_ctime=no],[ax_cv_allocated_ctime=no]
   ) # end of TRY_RUN]) # end of CACHE_VAL
 
   AC_MSG_RESULT([$ax_cv_allocated_ctime])

--- a/m4/ax_check_page_aligned_malloc.m4
+++ b/m4/ax_check_page_aligned_malloc.m4
@@ -36,12 +36,12 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 10
+#serial 11
 
 AC_DEFUN([AX_CHECK_PAGE_ALIGNED_MALLOC],
 [AC_CACHE_CHECK([if large mallocs guarantee page-alignment],
   [ax_cv_func_malloc_aligned],
-  [AC_TRY_RUN([
+  [AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <stdio.h>
 #include <stdlib.h>
 #if HAVE_UNISTD_H
@@ -58,7 +58,7 @@ int main()
       exit (1);
   exit (0);
 }
-              ],
+  ]])],
      [ax_cv_func_malloc_aligned=yes],
      [ax_cv_func_malloc_aligned=no],
      [ax_cv_func_malloc_aligned=no])

--- a/m4/ax_check_pathfind.m4
+++ b/m4/ax_check_pathfind.m4
@@ -21,18 +21,18 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 6
+#serial 7
 
 AU_ALIAS([AG_CHECK_PATHFIND], [AX_CHECK_PATHFIND])
 AC_DEFUN([AX_CHECK_PATHFIND],[
   AC_MSG_CHECKING([whether pathfind(3) works])
   AC_CACHE_VAL([ax_cv_pathfind],[
-  AC_TRY_RUN([#include <string.h>
+  AC_RUN_IFELSE([AC_LANG_SOURCE([[#include <string.h>
 #include <stdlib.h>
 int main (int argc, char** argv) {
    char* pz = pathfind( getenv( "PATH" ), "sh", "x" );
    return (pz == 0) ? 1 : 0;
-}],[ax_cv_pathfind=yes],[ax_cv_pathfind=no],[ax_cv_pathfind=no]
+}]])],[ax_cv_pathfind=yes],[ax_cv_pathfind=no],[ax_cv_pathfind=no]
   ) # end of TRY_RUN]) # end of CACHE_VAL
 
   AC_MSG_RESULT([$ax_cv_pathfind])

--- a/m4/ax_check_posix_regcomp.m4
+++ b/m4/ax_check_posix_regcomp.m4
@@ -21,20 +21,20 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 6
+#serial 7
 
 AU_ALIAS([AG_CHECK_POSIX_REGCOMP], [AX_CHECK_POSIX_REGCOMP])
 AC_DEFUN([AX_CHECK_POSIX_REGCOMP],[
   AC_MSG_CHECKING([whether POSIX compliant regcomp()/regexec()])
   AC_CACHE_VAL([ax_cv_posix_regcomp],[
-  AC_TRY_RUN([#include <sys/types.h>
+  AC_RUN_IFELSE([AC_LANG_SOURCE([[#include <sys/types.h>
 #include <regex.h>
 int main() {
   int flags = REG_EXTENDED|REG_ICASE|REG_NEWLINE;
   regex_t  re;
   if (regcomp( &re, "^.*$", flags ) != 0)
     return 1;
-  return regcomp( &re, "|no.*", flags ); }],[ax_cv_posix_regcomp=yes],[ax_cv_posix_regcomp=no],[ax_cv_posix_regcomp=no]
+  return regcomp( &re, "|no.*", flags ); }]])],[ax_cv_posix_regcomp=yes],[ax_cv_posix_regcomp=no],[ax_cv_posix_regcomp=no]
   ) # end of TRY_RUN]) # end of CACHE_VAL
 
   AC_MSG_RESULT([$ax_cv_posix_regcomp])

--- a/m4/ax_check_posix_sysinfo.m4
+++ b/m4/ax_check_posix_sysinfo.m4
@@ -20,16 +20,16 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 6
+#serial 7
 
 AU_ALIAS([AG_CHECK_POSIX_SYSINFO], [AX_CHECK_POSIX_SYSINFO])
 AC_DEFUN([AX_CHECK_POSIX_SYSINFO],[
   AC_MSG_CHECKING([whether sysinfo(2) is POSIX])
   AC_CACHE_VAL([ax_cv_posix_sysinfo],[
-  AC_TRY_RUN([#include <sys/systeminfo.h>
+  AC_RUN_IFELSE([AC_LANG_SOURCE([[#include <sys/systeminfo.h>
 int main() { char z[ 256 ];
 long sz = sysinfo( SI_SYSNAME, z, sizeof( z ));
-return (sz > 0) ? 0 : 1; }],[ax_cv_posix_sysinfo=yes],[ax_cv_posix_sysinfo=no],[ax_cv_posix_sysinfo=no]
+return (sz > 0) ? 0 : 1; }]])],[ax_cv_posix_sysinfo=yes],[ax_cv_posix_sysinfo=no],[ax_cv_posix_sysinfo=no]
   ) # end of TRY_RUN]) # end of CACHE_VAL
 
   AC_MSG_RESULT([$ax_cv_posix_sysinfo])

--- a/m4/ax_check_strcspn.m4
+++ b/m4/ax_check_strcspn.m4
@@ -32,18 +32,18 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 6
+#serial 7
 
 AU_ALIAS([AG_CHECK_STRCSPN], [AX_CHECK_STRCSPN])
 AC_DEFUN([AX_CHECK_STRCSPN],[
   AC_MSG_CHECKING([whether strcspn matches prototype and works])
   AC_CACHE_VAL([ax_cv_strcspn],[
-  AC_TRY_RUN([#include <string.h>
+  AC_RUN_IFELSE([AC_LANG_SOURCE([[#include <string.h>
 int main (int argc, char** argv) {
    char zRej[] = "reject";
    char zAcc[] = "a-ok-eject";
    return strcspn( zAcc, zRej ) - 5;
-}],[ax_cv_strcspn=yes],[ax_cv_strcspn=no],[ax_cv_strcspn=no]
+}]])],[ax_cv_strcspn=yes],[ax_cv_strcspn=no],[ax_cv_strcspn=no]
   ) # end of TRY_RUN]) # end of CACHE_VAL
 
   AC_MSG_RESULT([$ax_cv_strcspn])

--- a/m4/ax_check_strftime.m4
+++ b/m4/ax_check_strftime.m4
@@ -19,13 +19,13 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 6
+#serial 7
 
 AU_ALIAS([AG_CHECK_STRFTIME], [AX_CHECK_STRFTIME])
 AC_DEFUN([AX_CHECK_STRFTIME],[
   AC_MSG_CHECKING([whether strftime() works])
   AC_CACHE_VAL([ax_cv_strftime],[
-  AC_TRY_RUN([#include <time.h>
+  AC_RUN_IFELSE([AC_LANG_SOURCE([[#include <time.h>
 char t_buf[ 64 ];
 int main() {
   static const char z[] = "Thursday Aug 28 240";
@@ -40,7 +40,7 @@ int main() {
   tm.tm_yday  = 239; /* days since January 1 [0, 365] */
   tm.tm_isdst =  1;  /* flag for daylight savings time */
   strftime( t_buf, sizeof( t_buf ), "%A %b %d %j", &tm );
-  return (strcmp( t_buf, z ) != 0); }],[ax_cv_strftime=yes],[ax_cv_strftime=no],[ax_cv_strftime=no]
+  return (strcmp( t_buf, z ) != 0); }]])],[ax_cv_strftime=yes],[ax_cv_strftime=no],[ax_cv_strftime=no]
   ) # end of TRY_RUN]) # end of CACHE_VAL
 
   AC_MSG_RESULT([$ax_cv_strftime])

--- a/m4/ax_check_sys_siglist.m4
+++ b/m4/ax_check_sys_siglist.m4
@@ -19,16 +19,16 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 6
+#serial 7
 
 AU_ALIAS([AG_CHECK_SYS_SIGLIST], [AX_CHECK_SYS_SIGLIST])
 AC_DEFUN([AX_CHECK_SYS_SIGLIST],[
   AC_MSG_CHECKING([whether there is a global text array sys_siglist])
   AC_CACHE_VAL([ax_cv_sys_siglist],[
-  AC_TRY_RUN([#include <signal.h>
+  AC_RUN_IFELSE([AC_LANG_SOURCE([[#include <signal.h>
 int main() {
   const char* pz = sys_siglist[1];
-  return (pz != 0) ? 0 : 1; }],[ax_cv_sys_siglist=yes],[ax_cv_sys_siglist=no],[ax_cv_sys_siglist=no]
+  return (pz != 0) ? 0 : 1; }]])],[ax_cv_sys_siglist=yes],[ax_cv_sys_siglist=no],[ax_cv_sys_siglist=no]
   ) # end of TRY_RUN]) # end of CACHE_VAL
 
   AC_MSG_RESULT([$ax_cv_sys_siglist])

--- a/m4/ax_check_uname_syscall.m4
+++ b/m4/ax_check_uname_syscall.m4
@@ -19,15 +19,15 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 6
+#serial 7
 
 AU_ALIAS([AG_CHECK_UNAME_SYSCALL], [AX_CHECK_UNAME_SYSCALL])
 AC_DEFUN([AX_CHECK_UNAME_SYSCALL],[
   AC_MSG_CHECKING([whether uname(2) is POSIX])
   AC_CACHE_VAL([ax_cv_uname_syscall],[
-  AC_TRY_RUN([#include <sys/utsname.h>
+  AC_RUN_IFELSE([AC_LANG_SOURCE([[#include <sys/utsname.h>
 int main() { struct utsname unm;
-return uname( &unm ); }],[ax_cv_uname_syscall=yes],[ax_cv_uname_syscall=no],[ax_cv_uname_syscall=no]
+return uname( &unm ); }]])],[ax_cv_uname_syscall=yes],[ax_cv_uname_syscall=no],[ax_cv_uname_syscall=no]
   ) # end of TRY_RUN]) # end of CACHE_VAL
 
   AC_MSG_RESULT([$ax_cv_uname_syscall])

--- a/m4/ax_ext.m4
+++ b/m4/ax_ext.m4
@@ -44,7 +44,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 17
+#serial 18
 
 AC_DEFUN([AX_EXT],
 [
@@ -160,7 +160,7 @@ AC_DEFUN([AX_EXT],
         ax_cv_have_sse_os_support_ext=no,
         if test "$((0x$edx_cpuid1>>25&0x01))" = 1; then
           AC_LANG_PUSH([C])
-          AC_TRY_RUN([
+          AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <signal.h>
 #include <stdlib.h>
             /* No way at ring1 to ring3 in protected mode to check the CR0 and CR4
@@ -172,10 +172,10 @@ AC_DEFUN([AX_EXT],
               /* SSE instruction xorps  %xmm0,%xmm0 */
               __asm__ __volatile__ (".byte 0x0f, 0x57, 0xc0");
               return 0;
-            }],
-            ax_cv_have_sse_os_support_ext=yes,
-            ax_cv_have_sse_os_support_ext=no,
-            ax_cv_have_sse_os_support_ext=no)
+            }]])],
+            [ax_cv_have_sse_os_support_ext=yes],
+            [ax_cv_have_sse_os_support_ext=no],
+            [ax_cv_have_sse_os_support_ext=no])
           AC_LANG_POP([C])
         fi
       ])

--- a/m4/ax_func_memmove.m4
+++ b/m4/ax_func_memmove.m4
@@ -20,15 +20,14 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 6
+#serial 7
 
 AU_ALIAS([AC_FUNC_MEMMOVE], [AX_FUNC_MEMMOVE])
 AC_DEFUN([AX_FUNC_MEMMOVE],
 [AC_CHECK_FUNCS(memmove)
 AC_MSG_CHECKING(for working memmove)
 AC_CACHE_VAL(ac_cv_have_working_memmove,
-[AC_TRY_RUN(
-[#include <stdio.h>
+[AC_RUN_IFELSE([AC_LANG_SOURCE([[#include <stdio.h>
 
 int main(void)
 {
@@ -42,7 +41,7 @@ int main(void)
     if (strcmp (buf, "01012567"))
         exit (1);
     exit (0);
-}], ac_cv_have_working_memmove=yes, ac_cv_have_working_memmove=no, ac_cv_have_working_memmove=cross)])
+}]])],[ac_cv_have_working_memmove=yes],[ac_cv_have_working_memmove=no],[ac_cv_have_working_memmove=cross])])
 AC_MSG_RESULT([$ac_cv_have_working_memmove])
 if test x$ac_cv_have_working_memmove != "xyes"; then
   AC_LIBOBJ(memmove)

--- a/m4/ax_func_posix_memalign.m4
+++ b/m4/ax_func_posix_memalign.m4
@@ -22,12 +22,12 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 8
+#serial 9
 
 AC_DEFUN([AX_FUNC_POSIX_MEMALIGN],
 [AC_CACHE_CHECK([for working posix_memalign],
   [ax_cv_func_posix_memalign_works],
-  [AC_TRY_RUN([
+  [AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <stdlib.h>
 
 int
@@ -39,7 +39,7 @@ main ()
    * the size word. */
   exit (posix_memalign (&buffer, sizeof(void *), 123) != 0);
 }
-    ],
+    ]])],
     [ax_cv_func_posix_memalign_works=yes],
     [ax_cv_func_posix_memalign_works=no],
     [ax_cv_func_posix_memalign_works=no])])

--- a/m4/ax_func_snprintf.m4
+++ b/m4/ax_func_snprintf.m4
@@ -24,15 +24,14 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 6
+#serial 7
 
 AU_ALIAS([AC_FUNC_SNPRINTF], [AX_FUNC_SNPRINTF])
 AC_DEFUN([AX_FUNC_SNPRINTF],
 [AC_CHECK_FUNCS(snprintf vsnprintf)
 AC_MSG_CHECKING(for working snprintf)
 AC_CACHE_VAL(ac_cv_have_working_snprintf,
-[AC_TRY_RUN(
-[#include <stdio.h>
+[AC_RUN_IFELSE([AC_LANG_SOURCE([[#include <stdio.h>
 
 int main(void)
 {
@@ -46,12 +45,11 @@ int main(void)
     if (strcmp (bufd, "1")) exit (1);
     if (i != 3) exit (1);
     exit(0);
-}], ac_cv_have_working_snprintf=yes, ac_cv_have_working_snprintf=no, ac_cv_have_working_snprintf=cross)])
+}]])],[ac_cv_have_working_snprintf=yes],[ac_cv_have_working_snprintf=no],[ac_cv_have_working_snprintf=cross])])
 AC_MSG_RESULT([$ac_cv_have_working_snprintf])
 AC_MSG_CHECKING(for working vsnprintf)
 AC_CACHE_VAL(ac_cv_have_working_vsnprintf,
-[AC_TRY_RUN(
-[#include <stdio.h>
+[AC_RUN_IFELSE([AC_LANG_SOURCE([[#include <stdio.h>
 #include <stdarg.h>
 
 int my_vsnprintf (char *buf, const char *tmpl, ...)
@@ -76,7 +74,7 @@ int main(void)
     if (strcmp (bufd, "1")) exit (1);
     if (i != 3) exit (1);
     exit(0);
-}], ac_cv_have_working_vsnprintf=yes, ac_cv_have_working_vsnprintf=no, ac_cv_have_working_vsnprintf=cross)])
+}]])],[ac_cv_have_working_vsnprintf=yes],[ac_cv_have_working_vsnprintf=no],[ac_cv_have_working_vsnprintf=cross])])
 AC_MSG_RESULT([$ac_cv_have_working_vsnprintf])
 if test x$ac_cv_have_working_snprintf$ac_cv_have_working_vsnprintf != "xyesyes"; then
   AC_LIBOBJ(snprintf)


### PR DESCRIPTION
Hello,

Autoconf made several macros obsolete including the `AC_TRY_RUN` and in 2000 and since Autoconf 2.50:
http://git.savannah.gnu.org/cgit/autoconf.git/tree/ChangeLog.2

These macros should be replaced with the current `AC_RUN_IFELSE` instead.

This patch was created with the help of the autoupdate script.

Reference docs:
- https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Obsolete-Macros.html
- https://www.gnu.org/software/autoconf/manual/autoconf-2.59/autoconf.pdf