### PR TITLE
Replace obsolete AC_TRY_CPP with AC_PREPROC_IFELSE

### DIFF
--- a/m4/ax_prog_javah.m4
+++ b/m4/ax_prog_javah.m4
@@ -21,7 +21,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 10
+#serial 11
 
 AU_ALIAS([AC_PROG_JAVAH], [AX_PROG_JAVAH])
 AC_DEFUN([AX_PROG_JAVAH],[
@@ -30,9 +30,9 @@ AC_REQUIRE([AC_PROG_CPP])dnl
 AC_PATH_PROG(JAVAH,javah)
 AS_IF([test -n "$ac_cv_path_JAVAH"],
       [
-        AC_TRY_CPP([#include <jni.h>],,[
+        AC_PREPROC_IFELSE([AC_LANG_SOURCE([[#include <jni.h>]])],[],[
         ac_save_CPPFLAGS="$CPPFLAGS"
-		_ACJAVAH_FOLLOW_SYMLINKS("$ac_cv_path_JAVAH")
+        _ACJAVAH_FOLLOW_SYMLINKS("$ac_cv_path_JAVAH")
         ax_prog_javah_bin_dir=`AS_DIRNAME([$_ACJAVAH_FOLLOWED])`
         ac_dir="`AS_DIRNAME([$ax_prog_javah_bin_dir])`/include"
         AS_CASE([$build_os],
@@ -40,9 +40,9 @@ AS_IF([test -n "$ac_cv_path_JAVAH"],
                 [ac_machdep=win32],
                 [ac_machdep=`AS_ECHO($build_os) | sed 's,[[-0-9]].*,,'`])
         CPPFLAGS="$ac_save_CPPFLAGS -I$ac_dir -I$ac_dir/$ac_machdep"
-        AC_TRY_CPP([#include <jni.h>],
-                   ac_save_CPPFLAGS="$CPPFLAGS",
-                   AC_MSG_WARN([unable to include <jni.h>]))
+        AC_PREPROC_IFELSE([AC_LANG_SOURCE([[#include <jni.h>]])],
+                          [ac_save_CPPFLAGS="$CPPFLAGS"],
+                          [AC_MSG_WARN([unable to include <jni.h>])])
         CPPFLAGS="$ac_save_CPPFLAGS"])
       ])
 ])


### PR DESCRIPTION
The `AC_TRY_CPP` macro has been made obsolete in Autoconf 2.50 which was released in 2001. It should be replaced with `AC_PREPROC_IFELSE` macro.

Refs:
- https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/AC_005fACT_005fIFELSE-vs-AC_005fTRY_005fACT.html
- https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Running-the-Preprocessor.html