### PR TITLE
Replace obsolete AC_TRY_LINK macros with AC_LINK_IFELSE

### DIFF
--- a/m4/ax_afs.m4
+++ b/m4/ax_afs.m4
@@ -34,7 +34,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([SG_AFS], [AX_AFS])
 AC_DEFUN([AX_AFS],
@@ -55,10 +55,10 @@ AC_MAX_CHECKING([whether the specified AFS dir looks valid])
 if test "x${ax_cv_afsdir_link_works:-set}" != "x$ax_cv_with_afsdir"; then
         save_LIBS="$LIBS"
         LIBS="$save_LIBS -lcmd"
-        AC_TRY_LINK([#include <afs/cmd.h>],
-                [cmd_CreateAlias((struct cmd_syndesc *)0, "foo")],
-                ax_cv_afsdir_link_works=$ax_cv_with_afsdir,
-                ax_cv_afsdir_link_works=_FAILED_)
+        AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <afs/cmd.h>]],
+                [[cmd_CreateAlias((struct cmd_syndesc *)0, "foo")]])],
+                [ax_cv_afsdir_link_works=$ax_cv_with_afsdir],
+                [ax_cv_afsdir_link_works=_FAILED_])
         LIBS="$save_LIBS"
         wasCached=""
 else

--- a/m4/ax_include_strcasecmp.m4
+++ b/m4/ax_include_strcasecmp.m4
@@ -25,23 +25,21 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 2
+#serial 3
 
 AC_DEFUN([AX_INCLUDE_STRCASECMP],
 [
 AC_CACHE_CHECK([for strcasecmp header file], [ax_cv_include_strcasecmp_found], [
         ax_cv_include_strcasecmp_found=no
-        AC_TRY_LINK(
-                [ #include <strings.h> ],
-                [ strcasecmp("foo", "bar"); ],
+        AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <strings.h>]],
+                [[strcasecmp("foo", "bar");]])],
                 [ax_cv_include_strcasecmp_found='<strings.h>'],
                 [ax_cv_include_strcasecmp_found=no])
 
         if test x"$ax_cv_include_strcasecmp_found" = "xno"
         then
-        AC_TRY_LINK(
-                [ #include <string.h> ],
-                [ strcasecmp("foo", "bar"); ],
+        AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <string.h>]],
+                [[strcasecmp("foo", "bar");]])],
                 [ax_cv_include_strcasecmp_found='<string.h>'],
                 [ax_cv_include_strcasecmp_found=no])
         fi

--- a/m4/ax_ruby_devel.m4
+++ b/m4/ax_ruby_devel.m4
@@ -52,7 +52,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 14
+#serial 15
 
 AC_DEFUN([AX_RUBY_DEVEL],[
     AX_WITH_PROG(RUBY,ruby)
@@ -147,11 +147,11 @@ $ac_rbconfig_result])
     LIBS="$ac_save_LIBS $RUBY_LDFLAGS"
     ac_save_CPPFLAGS="$CPPFLAGS"
     CPPFLAGS="$ac_save_CPPFLAGS $RUBY_CPPFLAGS"
-    AC_TRY_LINK([
+    AC_LINK_IFELSE([AC_LANG_PROGRAM([[
         #include <ruby.h>
-    ],[
+    ]], [[
         ruby_init();
-    ],[rubyexists=yes],[rubyexists=no])
+    ]])],[rubyexists=yes],[rubyexists=no])
 
     AC_MSG_RESULT([$rubyexists])
 

--- a/m4/ax_short_sleep.m4
+++ b/m4/ax_short_sleep.m4
@@ -23,21 +23,19 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([ETR_SHORT_SLEEP], [AX_SHORT_SLEEP])
 AC_DEFUN([AX_SHORT_SLEEP],
 [
         AC_MSG_CHECKING([for nap() in libc])
-        AC_TRY_LINK([ extern "C" long nap(long ms); ], [ nap(42); ],
-                [
+        AC_LINK_IFELSE([AC_LANG_PROGRAM([[extern "C" long nap(long ms);]], [[nap(42);]])], [
                         ax_ss_found=yes
                         ax_ss_factor=1
                         AC_DEFINE(HAVE_NAP,1,
                                 [Define to use the nap() system call for short sleeps])
                         AC_MSG_RESULT(yes)
-                ],
-                [
+                ],[
                         AC_MSG_RESULT(no)
                         ax_ss_found=no
                 ])
@@ -45,15 +43,13 @@ AC_DEFUN([AX_SHORT_SLEEP],
         if test x"$ax_ss_found" = "xno"
         then
                 AC_MSG_CHECKING([for usleep()])
-                AC_TRY_LINK([ #include <unistd.h> ], [ usleep(42); ],
-                        [
+                AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <unistd.h>]], [[usleep(42);]])],[
                                 ax_ss_found=yes
                                 ax_ss_factor=1000
                                 AC_DEFINE(HAVE_USLEEP,1,
                                         [Define to use the usleep() system call for short sleeps])
                                 AC_MSG_RESULT(yes)
-                        ],
-                        [
+                        ],[
                                 AC_MSG_RESULT(no)
                                 ax_ss_found=no
                         ])
@@ -64,15 +60,13 @@ AC_DEFUN([AX_SHORT_SLEEP],
                 save_LIBS=$LIBS
                 LIBS="$LIBS -lx"
                 AC_MSG_CHECKING([for nap() in libx])
-                AC_TRY_LINK([ extern "C" long nap(long ms); ], [ nap(42); ],
-                        [
+                AC_LINK_IFELSE([AC_LANG_PROGRAM([[extern "C" long nap(long ms);]], [[nap(42);]])],[
                                 ax_ss_found=yes
                                 ax_ss_factor=1
                                 AC_DEFINE(HAVE_NAP,1,
                                         [Define to use the nap() system call for short sleeps])
                                 AC_MSG_RESULT(yes)
-                        ],
-                        [
+                        ],[
                                 AC_MSG_RESULT(no)
                                 ax_ss_found=no
                         ])

--- a/m4/ax_string_strcasecmp.m4
+++ b/m4/ax_string_strcasecmp.m4
@@ -31,17 +31,17 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 8
+#serial 9
 
 AU_ALIAS([ETR_STRING_STRCASECMP], [AX_STRING_STRCASECMP])
 AC_DEFUN([AX_STRING_STRCASECMP],
 [
 AC_CACHE_CHECK([for strcasecmp() in string.h], ac_cv_string_strcasecmp, [
-        AC_TRY_LINK(
-                [ #include <string.h> ],
-                [ strcasecmp("foo", "bar"); ],
-                ac_cv_string_strcasecmp=yes,
-                ac_cv_string_strcasecmp=no)
+        AC_LINK_IFELSE([AC_LANG_PROGRAM(
+                [[#include <string.h>]],
+                [[strcasecmp("foo", "bar");]])],
+                [ac_cv_string_strcasecmp=yes],
+                [ac_cv_string_strcasecmp=no])
 ])
 
         if test x"$ac_cv_string_strcasecmp" = "xyes"

--- a/m4/ax_strings_strcasecmp.m4
+++ b/m4/ax_strings_strcasecmp.m4
@@ -20,17 +20,17 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 8
+#serial 9
 
 AU_ALIAS([ETR_STRINGS_STRCASECMP], [AX_STRINGS_STRCASECMP])
 AC_DEFUN([AX_STRINGS_STRCASECMP],
 [ AC_CACHE_CHECK([for strcasecmp() in strings.h], ac_cv_strings_strcasecmp, [
 
-        AC_TRY_LINK(
-                [ #include <strings.h> ],
-                [ strcasecmp("foo", "bar"); ],
-                ac_cv_strings_strcasecmp=yes,
-                ac_cv_strings_strcasecmp=no)
+        AC_LINK_IFELSE(
+                [AC_LANG_PROGRAM([[#include <strings.h>]],
+                        [[strcasecmp("foo", "bar");]])],
+                [ac_cv_strings_strcasecmp=yes],
+                [ac_cv_strings_strcasecmp=no])
 ])
 
         if test x"$ac_cv_strings_strcasecmp" = "xyes"

--- a/m4/ax_with_mpatrol.m4
+++ b/m4/ax_with_mpatrol.m4
@@ -28,7 +28,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 6
+#serial 7
 
 AU_ALIAS([AM_WITH_MPATROL], [AX_WITH_MPATROL])
 AC_DEFUN([AX_WITH_MPATROL], [
@@ -157,13 +157,13 @@ AC_DEFUN([AX_WITH_MPATROL], [
    # link a simple program with it.
 
    AC_CACHE_CHECK(for working mpatrol, am_cv_with_mpatrol, [
-     AC_TRY_LINK([#include <mpatrol.h>], [
+     AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <mpatrol.h>]], [[
 int main(void)
 {
     malloc(4);
     return EXIT_SUCCESS;
 }
-],
+]])],
       [am_cv_with_mpatrol=yes],
       [am_cv_with_mpatrol=no]
      )

--- a/m4/ax_xercesc.m4
+++ b/m4/ax_xercesc.m4
@@ -41,7 +41,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 8
+#serial 9
 
 AU_ALIAS([RLC_XERCESC], [AX_XERCESC])
 AC_DEFUN([AX_XERCESC],
@@ -59,12 +59,12 @@ AC_DEFUN([AX_XERCESC],
   AC_CACHE_CHECK([for libxerces-c], [ac_cv_libxerces_c], [
     ac_save_LIBS="$LIBS"
     LIBS="$LIBS $LIBXERCES_C $LIBICONV"
-    AC_TRY_LINK([
+    AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 #include <xercesc/util/PlatformUtils.hpp>
 #ifdef XERCES_CPP_NAMESPACE_USE
 XERCES_CPP_NAMESPACE_USE
 #endif
-         ], [
+         ]], [[
 try
 {
    XMLPlatformUtils::Initialize();
@@ -74,7 +74,7 @@ catch (...)
    // ...
 }
 XMLPlatformUtils::Terminate();
-         ], [ac_cv_libxerces_c=yes], [ac_cv_libxerces_c=no])
+         ]])],[ac_cv_libxerces_c=yes],[ac_cv_libxerces_c=no])
     LIBS="$ac_save_LIBS"
   ])
   if test "$ac_cv_libxerces_c" = yes; then


### PR DESCRIPTION
Autoconf 2.50 (released in 2001) made several macros obsolete including the `AC_TRY_LINK` which should now be replaced with the `AC_LINK_IFELSE`.

Refs:
- https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/AC_005fACT_005fIFELSE-vs-AC_005fTRY_005fACT.html
- https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Obsolete-Macros.html