### PR TITLE
Replace AC_TRY_LINK and AC_LANG_

### DIFF
--- a/m4/ax_cxx_have_complex_math1.m4
+++ b/m4/ax_cxx_have_complex_math1.m4
@@ -21,27 +21,26 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_HAVE_COMPLEX_MATH1], [AX_CXX_HAVE_COMPLEX_MATH1])
 AC_DEFUN([AX_CXX_HAVE_COMPLEX_MATH1],
 [AC_CACHE_CHECK(whether the compiler has complex math functions,
 ax_cv_cxx_have_complex_math1,
 [AC_REQUIRE([AX_CXX_NAMESPACES])
- AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
+ AC_LANG_PUSH([C++])
  ac_save_LIBS="$LIBS"
  LIBS="$LIBS -lm"
- AC_TRY_LINK([#include <complex>
+ AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <complex>
 #ifdef HAVE_NAMESPACES
 using namespace std;
-#endif],[complex<double> x(1.0, 1.0), y(1.0, 1.0);
+#endif]], [[complex<double> x(1.0, 1.0), y(1.0, 1.0);
 cos(x); cosh(x); exp(x); log(x); pow(x,1); pow(x,double(2.0));
 pow(x, y); pow(double(2.0), x); sin(x); sinh(x); sqrt(x); tan(x); tanh(x);
-return 0;],
- ax_cv_cxx_have_complex_math1=yes, ax_cv_cxx_have_complex_math1=no)
+return 0;]])],
+ [ax_cv_cxx_have_complex_math1=yes], [ax_cv_cxx_have_complex_math1=no])
  LIBS="$ac_save_LIBS"
- AC_LANG_RESTORE
+ AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_have_complex_math1" = yes; then
   AC_DEFINE(HAVE_COMPLEX_MATH1,,[define if the compiler has complex math functions])

--- a/m4/ax_cxx_have_complex_math2.m4
+++ b/m4/ax_cxx_have_complex_math2.m4
@@ -21,26 +21,25 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_HAVE_COMPLEX_MATH2], [AX_CXX_HAVE_COMPLEX_MATH2])
 AC_DEFUN([AX_CXX_HAVE_COMPLEX_MATH2],
 [AC_CACHE_CHECK(whether the compiler has more complex math functions,
 ax_cv_cxx_have_complex_math2,
 [AC_REQUIRE([AX_CXX_NAMESPACES])
- AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
+ AC_LANG_PUSH([C++])
  ac_save_LIBS="$LIBS"
  LIBS="$LIBS -lm"
- AC_TRY_LINK([#include <complex>
+ AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <complex>
 #ifdef HAVE_NAMESPACES
 using namespace std;
-#endif],[complex<double> x(1.0, 1.0), y(1.0, 1.0);
+#endif]], [[complex<double> x(1.0, 1.0), y(1.0, 1.0);
 acos(x); asin(x); atan(x); atan2(x,y); atan2(x, double(3.0));
-atan2(double(3.0), x); log10(x); return 0;],
- ax_cv_cxx_have_complex_math2=yes, ax_cv_cxx_have_complex_math2=no)
+atan2(double(3.0), x); log10(x); return 0;]])],
+ [ax_cv_cxx_have_complex_math2=yes], [ax_cv_cxx_have_complex_math2=no])
  LIBS="$ac_save_LIBS"
- AC_LANG_RESTORE
+ AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_have_complex_math2" = yes; then
   AC_DEFINE(HAVE_COMPLEX_MATH2,,[define if the compiler has more complex math functions])

--- a/m4/ax_cxx_have_ieee_math.m4
+++ b/m4/ax_cxx_have_ieee_math.m4
@@ -23,17 +23,16 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_HAVE_IEEE_MATH], [AX_CXX_HAVE_IEEE_MATH])
 AC_DEFUN([AX_CXX_HAVE_IEEE_MATH],
 [AC_CACHE_CHECK(whether the compiler supports IEEE math library,
 ax_cv_cxx_have_ieee_math,
-[AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
+[AC_LANG_PUSH([C++])
  ac_save_LIBS="$LIBS"
  LIBS="$LIBS -lm"
- AC_TRY_LINK([
+ AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 #ifndef _ALL_SOURCE
  #define _ALL_SOURCE
 #endif
@@ -43,7 +42,7 @@ ax_cv_cxx_have_ieee_math,
 #ifndef _XOPEN_SOURCE_EXTENDED
  #define _XOPEN_SOURCE_EXTENDED 1
 #endif
-#include <math.h>],[double x = 1.0; double y = 1.0; int i = 1;
+#include <math.h>]], [[double x = 1.0; double y = 1.0; int i = 1;
 acosh(x); asinh(x); atanh(x); cbrt(x); expm1(x); erf(x); erfc(x); isnan(x);
 j0(x); j1(x); jn(i,x); ilogb(x); logb(x); log1p(x); rint(x);
 y0(x); y1(x); yn(i,x);
@@ -55,10 +54,10 @@ gamma(x);
 lgamma(x);
 #endif
 hypot(x,y); nextafter(x,y); remainder(x,y); scalb(x,y);
-return 0;],
- ax_cv_cxx_have_ieee_math=yes, ax_cv_cxx_have_ieee_math=no)
+return 0;]])],
+ [ax_cv_cxx_have_ieee_math=yes], [ax_cv_cxx_have_ieee_math=no])
  LIBS="$ac_save_LIBS"
- AC_LANG_RESTORE
+ AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_have_ieee_math" = yes; then
   AC_DEFINE(HAVE_IEEE_MATH,,[define if the compiler supports IEEE math library])

--- a/m4/ax_cxx_have_system_v_math.m4
+++ b/m4/ax_cxx_have_system_v_math.m4
@@ -22,17 +22,16 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_HAVE_SYSTEM_V_MATH], [AX_CXX_HAVE_SYSTEM_V_MATH])
 AC_DEFUN([AX_CXX_HAVE_SYSTEM_V_MATH],
 [AC_CACHE_CHECK(whether the compiler supports System V math library,
 ax_cv_cxx_have_system_v_math,
-[AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
+[AC_LANG_PUSH([C++])
  ac_save_LIBS="$LIBS"
  LIBS="$LIBS -lm"
- AC_TRY_LINK([
+ AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 #ifndef _ALL_SOURCE
  #define _ALL_SOURCE
 #endif
@@ -42,13 +41,13 @@ ax_cv_cxx_have_system_v_math,
 #ifndef _XOPEN_SOURCE_EXTENDED
  #define _XOPEN_SOURCE_EXTENDED 1
 #endif
-#include <math.h>],[double x = 1.0; double y = 1.0;
+#include <math.h>]], [[double x = 1.0; double y = 1.0;
 _class(x); trunc(x); finite(x); itrunc(x); nearest(x); rsqrt(x); uitrunc(x);
 copysign(x,y); drem(x,y); unordered(x,y);
-return 0;],
- ax_cv_cxx_have_system_v_math=yes, ax_cv_cxx_have_system_v_math=no)
+return 0;]])],
+ [ax_cv_cxx_have_system_v_math=yes], [ax_cv_cxx_have_system_v_math=no])
  LIBS="$ac_save_LIBS"
- AC_LANG_RESTORE
+ AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_have_system_v_math" = yes; then
   AC_DEFINE(HAVE_SYSTEM_V_MATH,,[define if the compiler supports System V math library])


### PR DESCRIPTION
Autoconf 2.50 in 2001 made several macros obsolete. These include macros for temporary changing the language - `AC_LANG_SAVE`, `AC_LANG_CPLUSPLUS`, and `AC_LANG_RESTORE`. Instead of these the `AC_LANG_PUSH` and `AC_LANG_POP` macros should be used with later Autoconf versions.

`AC_TRY_LINK` macros should be replaced with `AC_LINK_IFELSE` and `AC_LANG_PROGRAM`.

Refs:
- http://git.savannah.gnu.org/cgit/autoconf.git/tree/NEWS
- https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Language-Choice.html
- https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Obsolete-Macros.html