### PR TITLE
Replace AC_TRY_COMPILE and AC_LANG_

### DIFF
--- a/m4/ax_cflags_force_c89.m4
+++ b/m4/ax_cflags_force_c89.m4
@@ -34,15 +34,14 @@
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 11
+#serial 12
 
 AC_DEFUN([AX_CFLAGS_FORCE_C89],[dnl
 AS_VAR_PUSHDEF([FLAGS],[CFLAGS])dnl
 AS_VAR_PUSHDEF([VAR],[ac_cv_cflags_force_c89])dnl
 AC_CACHE_CHECK([m4_ifval($1,$1,FLAGS) for C89 mode],
 VAR,[VAR="no, unknown"
- AC_LANG_SAVE
- AC_LANG_C
+ AC_LANG_PUSH([C])
  ac_save_[]FLAGS="$[]FLAGS"
 for ac_arg dnl
 in "-pedantic  % -ansi -pedantic"             dnl GCC
@@ -55,11 +54,12 @@ in "-pedantic  % -ansi -pedantic"             dnl GCC
    "-h conform % -h conform"                  dnl Cray C (Unicos)
    #
 do FLAGS="$ac_save_[]FLAGS "`echo $ac_arg | sed -e 's,%%.*,,' -e 's,%,,'`
-   AC_TRY_COMPILE([],[return 0;],
-   [VAR=`echo $ac_arg | sed -e 's,.*% *,,'` ; break])
+   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([],
+   [[return 0;]])],
+   [VAR=`echo $ac_arg | sed -e 's,.*% *,,'` ; break],[])
 done
  FLAGS="$ac_save_[]FLAGS"
- AC_LANG_RESTORE
+ AC_LANG_POP([C])
 ])
 AS_VAR_POPDEF([FLAGS])dnl
 AX_REQUIRE_DEFINED([AX_APPEND_FLAG])

--- a/m4/ax_check_zlib.m4
+++ b/m4/ax_check_zlib.m4
@@ -62,7 +62,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 15
+#serial 16
 
 AU_ALIAS([CHECK_ZLIB], [AX_CHECK_ZLIB])
 AC_DEFUN([AX_CHECK_ZLIB],
@@ -108,11 +108,10 @@ then
         LDFLAGS="$LDFLAGS -L${ZLIB_HOME}/lib"
         CPPFLAGS="$CPPFLAGS -I${ZLIB_HOME}/include"
   fi
-  AC_LANG_SAVE
-  AC_LANG_C
+  AC_LANG_PUSH([C])
   AC_CHECK_LIB([z], [inflateEnd], [zlib_cv_libz=yes], [zlib_cv_libz=no])
   AC_CHECK_HEADER([zlib.h], [zlib_cv_zlib_h=yes], [zlib_cv_zlib_h=no])
-  AC_LANG_RESTORE
+  AC_LANG_POP([C])
   if test "$zlib_cv_libz" = "yes" && test "$zlib_cv_zlib_h" = "yes"
   then
     #

--- a/m4/ax_cxx_compile_stdcxx_0x.m4
+++ b/m4/ax_cxx_compile_stdcxx_0x.m4
@@ -23,16 +23,15 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 11
+#serial 12
 
 AU_ALIAS([AC_CXX_COMPILE_STDCXX_0X], [AX_CXX_COMPILE_STDCXX_0X])
 AC_DEFUN([AX_CXX_COMPILE_STDCXX_0X], [
   AC_OBSOLETE([$0], [; use AX_CXX_COMPILE_STDCXX_11 instead])
   AC_CACHE_CHECK(if g++ supports C++0x features without additional flags,
   ax_cv_cxx_compile_cxx0x_native,
-  [AC_LANG_SAVE
-  AC_LANG_CPLUSPLUS
-  AC_TRY_COMPILE([
+  [AC_LANG_PUSH([C++])
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
   template <typename T>
     struct check
     {
@@ -46,18 +45,17 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX_0X], [
 
     typedef check<int> check_type;
     check_type c;
-    check_type&& cr = static_cast<check_type&&>(c);],,
-  ax_cv_cxx_compile_cxx0x_native=yes, ax_cv_cxx_compile_cxx0x_native=no)
-  AC_LANG_RESTORE
+    check_type&& cr = static_cast<check_type&&>(c);]], [])],
+  [ax_cv_cxx_compile_cxx0x_native=yes], [ax_cv_cxx_compile_cxx0x_native=no])
+  AC_LANG_POP([C++])
   ])
 
   AC_CACHE_CHECK(if g++ supports C++0x features with -std=c++0x,
   ax_cv_cxx_compile_cxx0x_cxx,
-  [AC_LANG_SAVE
-  AC_LANG_CPLUSPLUS
+  [AC_LANG_PUSH([C++])
   ac_save_CXX="$CXX"
   CXX="$CXX -std=c++0x"
-  AC_TRY_COMPILE([
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
   template <typename T>
     struct check
     {
@@ -71,19 +69,18 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX_0X], [
 
     typedef check<int> check_type;
     check_type c;
-    check_type&& cr = static_cast<check_type&&>(c);],,
-  ax_cv_cxx_compile_cxx0x_cxx=yes, ax_cv_cxx_compile_cxx0x_cxx=no)
+    check_type&& cr = static_cast<check_type&&>(c);]], [])],
+  [ax_cv_cxx_compile_cxx0x_cxx=yes], [ax_cv_cxx_compile_cxx0x_cxx=no])
   CXX="$ac_save_CXX"
-  AC_LANG_RESTORE
+  AC_LANG_POP([C++])
   ])
 
   AC_CACHE_CHECK(if g++ supports C++0x features with -std=gnu++0x,
   ax_cv_cxx_compile_cxx0x_gxx,
-  [AC_LANG_SAVE
-  AC_LANG_CPLUSPLUS
+  [AC_LANG_PUSH([C++])
   ac_save_CXX="$CXX"
   CXX="$CXX -std=gnu++0x"
-  AC_TRY_COMPILE([
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
   template <typename T>
     struct check
     {
@@ -97,10 +94,10 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX_0X], [
 
     typedef check<int> check_type;
     check_type c;
-    check_type&& cr = static_cast<check_type&&>(c);],,
-  ax_cv_cxx_compile_cxx0x_gxx=yes, ax_cv_cxx_compile_cxx0x_gxx=no)
+    check_type&& cr = static_cast<check_type&&>(c);]], [])],
+  [ax_cv_cxx_compile_cxx0x_gxx=yes], [ax_cv_cxx_compile_cxx0x_gxx=no])
   CXX="$ac_save_CXX"
-  AC_LANG_RESTORE
+  AC_LANG_POP([C++])
   ])
 
   if test "$ax_cv_cxx_compile_cxx0x_native" = yes ||

--- a/m4/ax_cxx_dynamic_cast.m4
+++ b/m4/ax_cxx_dynamic_cast.m4
@@ -20,20 +20,19 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_DYNAMIC_CAST], [AX_CXX_DYNAMIC_CAST])
 AC_DEFUN([AX_CXX_DYNAMIC_CAST],
 [AC_CACHE_CHECK(whether the compiler supports dynamic_cast<>,
 ax_cv_cxx_dynamic_cast,
-[AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
- AC_TRY_COMPILE([#include <typeinfo>
+[AC_LANG_PUSH([C++])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <typeinfo>
 class Base { public : Base () {} virtual void f () = 0;};
-class Derived : public Base { public : Derived () {} virtual void f () {} };],[
-Derived d; Base& b=d; return dynamic_cast<Derived*>(&b) ? 0 : 1;],
- ax_cv_cxx_dynamic_cast=yes, ax_cv_cxx_dynamic_cast=no)
- AC_LANG_RESTORE
+class Derived : public Base { public : Derived () {} virtual void f () {} };]], [[
+Derived d; Base& b=d; return dynamic_cast<Derived*>(&b) ? 0 : 1;]])],
+ [ax_cv_cxx_dynamic_cast=yes], [ax_cv_cxx_dynamic_cast=no])
+ AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_dynamic_cast" = yes; then
   AC_DEFINE(HAVE_DYNAMIC_CAST,,[define if the compiler supports dynamic_cast<>])

--- a/m4/ax_cxx_enum_computations.m4
+++ b/m4/ax_cxx_enum_computations.m4
@@ -21,15 +21,14 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_ENUM_COMPUTATIONS], [AX_CXX_ENUM_COMPUTATIONS])
 AC_DEFUN([AX_CXX_ENUM_COMPUTATIONS],
 [AC_CACHE_CHECK(whether the compiler handle computations inside an enum,
 ax_cv_cxx_enum_computations,
-[AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
- AC_TRY_COMPILE([
+[AC_LANG_PUSH([C++])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 struct A { enum { a = 5, b = 7, c = 2 }; };
 struct B { enum { a = 1, b = 6, c = 9 }; };
 template<class T1, class T2> struct Z
@@ -37,12 +36,12 @@ template<class T1, class T2> struct Z
          b = T1::b + T2::b,
          c = (T1::c * T2::c + T2::a + T1::a)
        };
-};],[
+};]], [[
 return (((int)Z<A,B>::a == 5)
      && ((int)Z<A,B>::b == 13)
-     && ((int)Z<A,B>::c == 24)) ? 0 : 1;],
- ax_cv_cxx_enum_computations=yes, ax_cv_cxx_enum_computations=no)
- AC_LANG_RESTORE
+     && ((int)Z<A,B>::c == 24)) ? 0 : 1;]])],
+ [ax_cv_cxx_enum_computations=yes], [ax_cv_cxx_enum_computations=no])
+ AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_enum_computations" = yes; then
   AC_DEFINE(HAVE_ENUM_COMPUTATIONS,,

--- a/m4/ax_cxx_enum_computations_with_cast.m4
+++ b/m4/ax_cxx_enum_computations_with_cast.m4
@@ -21,15 +21,14 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_ENUM_COMPUTATIONS_WITH_CAST], [AX_CXX_ENUM_COMPUTATIONS_WITH_CAST])
 AC_DEFUN([AX_CXX_ENUM_COMPUTATIONS_WITH_CAST],
-[AC_CACHE_CHECK(whether the compiler handles (int) casts in enum computations,
+[AC_CACHE_CHECK([whether the compiler handles (int) casts in enum computations],
 ax_cv_cxx_enum_computations_with_cast,
-[AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
- AC_TRY_COMPILE([
+[AC_LANG_PUSH([C++])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 struct A { enum { a = 5, b = 7, c = 2 }; };
 struct B { enum { a = 1, b = 6, c = 9 }; };
 template<class T1, class T2> struct Z
@@ -37,12 +36,12 @@ template<class T1, class T2> struct Z
          b = (int)T1::b + (int)T2::b,
          c = ((int)T1::c * (int)T2::c + (int)T2::a + (int)T1::a)
        };
-};],[
+};]], [[
 return (((int)Z<A,B>::a == 5)
      && ((int)Z<A,B>::b == 13)
-     && ((int)Z<A,B>::c == 24)) ? 0 : 1;],
- ax_cv_cxx_enum_computations_with_cast=yes, ax_cv_cxx_enum_computations_with_cast=no)
- AC_LANG_RESTORE
+     && ((int)Z<A,B>::c == 24)) ? 0 : 1;]])],
+ [ax_cv_cxx_enum_computations_with_cast=yes], [ax_cv_cxx_enum_computations_with_cast=no])
+ AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_enum_computations_with_cast" = yes; then
   AC_DEFINE(HAVE_ENUM_COMPUTATIONS_WITH_CAST,,

--- a/m4/ax_cxx_exceptions.m4
+++ b/m4/ax_cxx_exceptions.m4
@@ -21,17 +21,17 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_EXCEPTIONS], [AX_CXX_EXCEPTIONS])
 AC_DEFUN([AX_CXX_EXCEPTIONS],
 [AC_CACHE_CHECK(whether the compiler supports exceptions,
 ax_cv_cxx_exceptions,
-[AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
- AC_TRY_COMPILE(,[try { throw  1; } catch (int i) { return i; }],
- ax_cv_cxx_exceptions=yes, ax_cv_cxx_exceptions=no)
- AC_LANG_RESTORE
+[AC_LANG_PUSH([C++])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([],
+ [[try { throw 1; } catch (int i) { return i; }]])],
+ [ax_cv_cxx_exceptions=yes], [ax_cv_cxx_exceptions=no])
+ AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_exceptions" = yes; then
   AC_DEFINE(HAVE_EXCEPTIONS,,[define if the compiler supports exceptions])

--- a/m4/ax_cxx_explicit.m4
+++ b/m4/ax_cxx_explicit.m4
@@ -22,18 +22,17 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_EXPLICIT], [AX_CXX_EXPLICIT])
 AC_DEFUN([AX_CXX_EXPLICIT],
 [AC_CACHE_CHECK(whether the compiler supports the explicit keyword,
 ax_cv_cxx_explicit,
-[AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
- AC_TRY_COMPILE([class A{public:explicit A(double){}};],
-[double c = 5.0;A x(c);return 0;],
- ax_cv_cxx_explicit=yes, ax_cv_cxx_explicit=no)
- AC_LANG_RESTORE
+[AC_LANG_PUSH([C++])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[class A{public:explicit A(double){}};]],
+ [[double c = 5.0;A x(c);return 0;]])],
+ [ax_cv_cxx_explicit=yes], [ax_cv_cxx_explicit=no])
+ AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_explicit" = yes; then
   AC_DEFINE(HAVE_EXPLICIT,,[define if the compiler supports the explicit keyword])

--- a/m4/ax_cxx_explicit_instantiations.m4
+++ b/m4/ax_cxx_explicit_instantiations.m4
@@ -21,17 +21,17 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 9
+#serial 10
 
 AU_ALIAS([AC_CXX_EXPLICIT_INSTANTIATIONS], [AX_CXX_EXPLICIT_INSTANTIATIONS])
 AC_DEFUN([AX_CXX_EXPLICIT_INSTANTIATIONS],
 [AC_CACHE_CHECK(whether the compiler supports explicit instantiations,
 ax_cv_cxx_explinst,
-[AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
- AC_TRY_COMPILE([template <class T> class A { T t; }; template class A<int>;],
- [], ax_cv_cxx_explinst=yes, ax_cv_cxx_explinst=no)
- AC_LANG_RESTORE
+[AC_LANG_PUSH([C++])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[template <class T> class A { T t; }; template class A<int>;]],
+ [])],
+ [ax_cv_cxx_explinst=yes],[ax_cv_cxx_explinst=no])
+ AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_explinst" = yes; then
   AC_DEFINE(HAVE_INSTANTIATIONS,,

--- a/m4/ax_cxx_explicit_template_function_qualification.m4
+++ b/m4/ax_cxx_explicit_template_function_qualification.m4
@@ -21,20 +21,19 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_EXPLICIT_TEMPLATE_FUNCTION_QUALIFICATION], [AX_CXX_EXPLICIT_TEMPLATE_FUNCTION_QUALIFICATION])
 AC_DEFUN([AX_CXX_EXPLICIT_TEMPLATE_FUNCTION_QUALIFICATION],
 [AC_CACHE_CHECK(whether the compiler supports explicit template function qualification,
 ax_cv_cxx_explicit_template_function_qualification,
-[AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
- AC_TRY_COMPILE([
+[AC_LANG_PUSH([C++])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 template<class Z> class A { public : A() {} };
 template<class X, class Y> A<X> to (const A<Y>&) { return A<X>(); }
-],[A<float> x; A<double> y = to<double>(x); return 0;],
- ax_cv_cxx_explicit_template_function_qualification=yes, ax_cv_cxx_explicit_template_function_qualification=no)
- AC_LANG_RESTORE
+]], [[A<float> x; A<double> y = to<double>(x); return 0;]])],
+ [ax_cv_cxx_explicit_template_function_qualification=yes], [ax_cv_cxx_explicit_template_function_qualification=no])
+ AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_explicit_template_function_qualification" = yes; then
   AC_DEFINE(HAVE_EXPLICIT_TEMPLATE_FUNCTION_QUALIFICATION,,

--- a/m4/ax_cxx_extern_template.m4
+++ b/m4/ax_cxx_extern_template.m4
@@ -19,18 +19,17 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_EXTERN_TEMPLATE], [AX_CXX_EXTERN_TEMPLATE])
 AC_DEFUN([AX_CXX_EXTERN_TEMPLATE],[
 AC_CACHE_CHECK(whether the compiler supports extern template,
 ax_cv_cxx_extern_template,
-[AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
- AC_TRY_COMPILE([template <typename T> void foo(T); extern template void foo<int>(int);],
- [],
- ax_cv_cxx_extern_template=yes, ax_cv_cxx_extern_template=no)
- AC_LANG_RESTORE
+[AC_LANG_PUSH([C++])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[template <typename T> void foo(T); extern template void foo<int>(int);]],
+ [])],
+ [ax_cv_cxx_extern_template=yes], [ax_cv_cxx_extern_template=no])
+ AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_extern_template" = yes; then
   AC_DEFINE(HAVE_EXTERN_TEMPLATE,,[define if the compiler supports extern template])

--- a/m4/ax_cxx_full_specialization_syntax.m4
+++ b/m4/ax_cxx_full_specialization_syntax.m4
@@ -21,20 +21,19 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_FULL_SPECIALIZATION_SYNTAX], [AX_CXX_FULL_SPECIALIZATION_SYNTAX])
 AC_DEFUN([AX_CXX_FULL_SPECIALIZATION_SYNTAX],
 [AC_CACHE_CHECK(whether the compiler recognizes the full specialization syntax,
 ax_cv_cxx_full_specialization_syntax,
-[AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
- AC_TRY_COMPILE([
+[AC_LANG_PUSH([C++])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 template<class T> class A        { public : int f () const { return 1; } };
-template<>        class A<float> { public:  int f () const { return 0; } };],[
-A<float> a; return a.f();],
- ax_cv_cxx_full_specialization_syntax=yes, ax_cv_cxx_full_specialization_syntax=no)
- AC_LANG_RESTORE
+template<>        class A<float> { public:  int f () const { return 0; } };]], [[
+A<float> a; return a.f();]])],
+ [ax_cv_cxx_full_specialization_syntax=yes], [ax_cv_cxx_full_specialization_syntax=no])
+ AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_full_specialization_syntax" = yes; then
   AC_DEFINE(HAVE_FULL_SPECIALIZATION_SYNTAX,,

--- a/m4/ax_cxx_function_nontype_parameters.m4
+++ b/m4/ax_cxx_function_nontype_parameters.m4
@@ -21,20 +21,19 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_FUNCTION_NONTYPE_PARAMETERS], [AX_CXX_FUNCTION_NONTYPE_PARAMETERS])
 AC_DEFUN([AX_CXX_FUNCTION_NONTYPE_PARAMETERS],
 [AC_CACHE_CHECK(whether the compiler supports function templates with non-type parameters,
 ax_cv_cxx_function_nontype_parameters,
-[AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
- AC_TRY_COMPILE([
+[AC_LANG_PUSH([C++])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 template<class T, int N> class A {};
 template<class T, int N> int f(const A<T,N>& x) { return 0; }
-],[A<double, 17> z; return f(z);],
- ax_cv_cxx_function_nontype_parameters=yes, ax_cv_cxx_function_nontype_parameters=no)
- AC_LANG_RESTORE
+]], [[A<double, 17> z; return f(z);]])],
+ [ax_cv_cxx_function_nontype_parameters=yes], [ax_cv_cxx_function_nontype_parameters=no])
+ AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_function_nontype_parameters" = yes; then
   AC_DEFINE(HAVE_FUNCTION_NONTYPE_PARAMETERS,,

--- a/m4/ax_cxx_function_try_blocks.m4
+++ b/m4/ax_cxx_function_try_blocks.m4
@@ -41,7 +41,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 5
+#serial 6
 
 AU_ALIAS([MDL_CXX_FUNCTION_TRY_BLOCKS], [AX_CXX_FUNCTION_TRY_BLOCKS])
 AC_DEFUN([AX_CXX_FUNCTION_TRY_BLOCKS],
@@ -52,13 +52,12 @@ AC_MSG_CHECKING(whether ${CXX} supports function try blocks)
 changequote([,])dnl
 AC_CACHE_VAL(ax_cv_have_function_try_blocks,
 [
-AC_LANG_SAVE
-AC_LANG_CPLUSPLUS
-AC_TRY_COMPILE([void foo() try{} catch( ... ){}],
-[foo();],
-ax_cv_have_function_try_blocks=yes,
-ax_cv_have_function_try_blocks=no)
-AC_LANG_RESTORE
+AC_LANG_PUSH([C++])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[void foo() try{} catch( ... ){}]],
+[[foo();]])],
+[ax_cv_have_function_try_blocks=yes],
+[ax_cv_have_function_try_blocks=no])
+AC_LANG_POP([C++])
 ])
 AC_MSG_RESULT($ax_cv_have_function_try_blocks)
 if test "$ax_cv_have_function_try_blocks" = yes; then

--- a/m4/ax_cxx_gcc_abi_demangle.m4
+++ b/m4/ax_cxx_gcc_abi_demangle.m4
@@ -23,20 +23,19 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 9
+#serial 10
 
 AC_DEFUN([AX_CXX_GCC_ABI_DEMANGLE],
 [AC_CACHE_CHECK(whether the compiler supports GCC C++ ABI name demangling,
 ax_cv_cxx_gcc_abi_demangle,
-[AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
- AC_TRY_COMPILE([#include <typeinfo>
+[AC_LANG_PUSH([C++])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <typeinfo>
 #include <cxxabi.h>
 #include <string>
 
 template<typename TYPE>
 class A {};
-],[A<int> instance;
+]], [[A<int> instance;
 int status = 0;
 char* c_name = 0;
 
@@ -46,9 +45,9 @@ std::string name(c_name);
 free(c_name);
 
 return name == "A<int>";
-],
- ax_cv_cxx_gcc_abi_demangle=yes, ax_cv_cxx_gcc_abi_demangle=no)
- AC_LANG_RESTORE
+]])],
+ [ax_cv_cxx_gcc_abi_demangle=yes], [ax_cv_cxx_gcc_abi_demangle=no])
+ AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_gcc_abi_demangle" = yes; then
   AC_DEFINE(HAVE_GCC_ABI_DEMANGLE,1,

--- a/m4/ax_cxx_gnucxx_hashmap.m4
+++ b/m4/ax_cxx_gnucxx_hashmap.m4
@@ -19,19 +19,18 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_GNUCXX_HASHMAP], [AX_CXX_GNUCXX_HASHMAP])
 AC_DEFUN([AX_CXX_GNUCXX_HASHMAP],[
 AC_CACHE_CHECK(whether the compiler supports __gnu_cxx::hash_map,
 ax_cv_cxx_gnucxx_hashmap,
-[AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
- AC_TRY_COMPILE([#include <ext/hash_map>
-using __gnu_cxx::hash_map;],
- [],
- ax_cv_cxx_gnucxx_hashmap=yes, ax_cv_cxx_gnucxx_hashmap=no)
- AC_LANG_RESTORE
+[AC_LANG_PUSH([C++])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <ext/hash_map>
+using __gnu_cxx::hash_map;]],
+ [])],
+ [ax_cv_cxx_gnucxx_hashmap=yes], [ax_cv_cxx_gnucxx_hashmap=no])
+ AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_gnucxx_hashmap" = yes; then
   AC_DEFINE(HAVE_GNUCXX_HASHMAP,,[define if the compiler supports __gnu_cxx::hash_map])

--- a/m4/ax_cxx_have_complex.m4
+++ b/m4/ax_cxx_have_complex.m4
@@ -20,21 +20,20 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_HAVE_COMPLEX], [AX_CXX_HAVE_COMPLEX])
 AC_DEFUN([AX_CXX_HAVE_COMPLEX],
 [AC_CACHE_CHECK(whether the compiler has complex<T>,
 ax_cv_cxx_have_complex,
 [AC_REQUIRE([AX_CXX_NAMESPACES])
- AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
- AC_TRY_COMPILE([#include <complex>
+ AC_LANG_PUSH([C++])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <complex>
 #ifdef HAVE_NAMESPACES
 using namespace std;
-#endif],[complex<float> a; complex<double> b; return 0;],
- ax_cv_cxx_have_complex=yes, ax_cv_cxx_have_complex=no)
- AC_LANG_RESTORE
+#endif]], [[complex<float> a; complex<double> b; return 0;]])],
+ [ax_cv_cxx_have_complex=yes], [ax_cv_cxx_have_complex=no])
+ AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_have_complex" = yes; then
   AC_DEFINE(HAVE_COMPLEX,,[define if the compiler has complex<T>])

--- a/m4/ax_cxx_have_empty_iostream.m4
+++ b/m4/ax_cxx_have_empty_iostream.m4
@@ -41,21 +41,20 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 6
+#serial 7
 
 AU_ALIAS([AC_CXX_HAVE_EMPTY_IOSTREAM], [AX_CXX_HAVE_EMPTY_IOSTREAM])
 AC_DEFUN([AX_CXX_HAVE_EMPTY_IOSTREAM],
 [AC_CACHE_CHECK(whether the compiler allow empty iostream,
 ax_cv_cxx_have_empty_iostream,
 [AC_REQUIRE([AX_CXX_NAMESPACES])
-  AC_LANG_SAVE
-  AC_LANG_CPLUSPLUS
-  AC_TRY_COMPILE([#include <iostream>
+  AC_LANG_PUSH([C++])
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <iostream>
 #ifdef HAVE_NAMESPACES
 using namespace std;
-#endif],[iostream iostr; return 0;],
-  ax_cv_cxx_have_empty_iostream=yes, ax_cv_cxx_have_empty_iostream=no)
-  AC_LANG_RESTORE
+#endif]], [[iostream iostr; return 0;]])],
+  [ax_cv_cxx_have_empty_iostream=yes], [ax_cv_cxx_have_empty_iostream=no])
+  AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_have_empty_iostream" = yes; then
    AC_DEFINE(HAVE_EMPTY_IOSTREAM,,[define if the compiler allow empty

--- a/m4/ax_cxx_have_ext_hash_map.m4
+++ b/m4/ax_cxx_have_ext_hash_map.m4
@@ -53,21 +53,20 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 6
+#serial 7
 
 AU_ALIAS([AC_CXX_HAVE_EXT_HASH_MAP], [AX_CXX_HAVE_EXT_HASH_MAP])
 AC_DEFUN([AX_CXX_HAVE_EXT_HASH_MAP],
 [AC_CACHE_CHECK(whether the compiler has ext/hash_map,
 ax_cv_cxx_have_ext_hash_map,
 [AC_REQUIRE([AX_CXX_NAMESPACES])
-  AC_LANG_SAVE
-  AC_LANG_CPLUSPLUS
-  AC_TRY_COMPILE([#include <ext/hash_map>
+  AC_LANG_PUSH([C++])
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <ext/hash_map>
 #ifdef HAVE_NAMESPACES
 using namespace std;
-#endif],[hash_map<int, int> t; return 0;],
-  ax_cv_cxx_have_ext_hash_map=yes, ax_cv_cxx_have_ext_hash_map=no)
-  AC_LANG_RESTORE
+#endif]], [[hash_map<int, int> t; return 0;]])],
+  [ax_cv_cxx_have_ext_hash_map=yes], [ax_cv_cxx_have_ext_hash_map=no])
+  AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_have_ext_hash_map" = yes; then
    AC_DEFINE(HAVE_EXT_HASH_MAP,,[define if the compiler has ext/hash_map])

--- a/m4/ax_cxx_have_ext_hash_set.m4
+++ b/m4/ax_cxx_have_ext_hash_set.m4
@@ -50,21 +50,20 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 6
+#serial 7
 
 AU_ALIAS([AC_CXX_HAVE_EXT_HASH_SET], [AX_CXX_HAVE_EXT_HASH_SET])
 AC_DEFUN([AX_CXX_HAVE_EXT_HASH_SET],
 [AC_CACHE_CHECK(whether the compiler has ext/hash_set,
 ax_cv_cxx_have_ext_hash_set,
 [AC_REQUIRE([AX_CXX_NAMESPACES])
-  AC_LANG_SAVE
-  AC_LANG_CPLUSPLUS
-  AC_TRY_COMPILE([#include <ext/hash_set>
+  AC_LANG_PUSH([C++])
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <ext/hash_set>
 #ifdef HAVE_NAMESPACES
 using namespace std;
-#endif],[hash_set<int> t; return 0;],
-  ax_cv_cxx_have_ext_hash_set=yes, ax_cv_cxx_have_ext_hash_set=no)
-  AC_LANG_RESTORE
+#endif]], [[hash_set<int> t; return 0;]])],
+  [ax_cv_cxx_have_ext_hash_set=yes], [ax_cv_cxx_have_ext_hash_set=no])
+  AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_have_ext_hash_set" = yes; then
    AC_DEFINE(HAVE_EXT_HASH_SET,,[define if the compiler has ext/hash_set])

--- a/m4/ax_cxx_have_ext_slist.m4
+++ b/m4/ax_cxx_have_ext_slist.m4
@@ -50,21 +50,20 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 6
+#serial 7
 
 AU_ALIAS([AC_CXX_HAVE_EXT_SLIST], [AX_CXX_HAVE_EXT_SLIST])
 AC_DEFUN([AX_CXX_HAVE_EXT_SLIST],
 [AC_CACHE_CHECK(whether the compiler has ext/slist,
 ax_cv_cxx_have_ext_slist,
 [AC_REQUIRE([AX_CXX_NAMESPACES])
-  AC_LANG_SAVE
-  AC_LANG_CPLUSPLUS
-  AC_TRY_COMPILE([#include <ext/slist>
+  AC_LANG_PUSH([C++])
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <ext/slist>
 #ifdef HAVE_NAMESPACES
 using namespace std;
-#endif],[slist<int> s; return 0;],
-  ax_cv_cxx_have_ext_slist=yes, ax_cv_cxx_have_ext_slist=no)
-  AC_LANG_RESTORE
+#endif]], [[slist<int> s; return 0;]])],
+  [ax_cv_cxx_have_ext_slist=yes], [ax_cv_cxx_have_ext_slist=no])
+  AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_have_ext_slist" = yes; then
    AC_DEFINE(HAVE_EXT_SLIST,,[define if the compiler has ext/slist])

--- a/m4/ax_cxx_have_freeze_sstream.m4
+++ b/m4/ax_cxx_have_freeze_sstream.m4
@@ -57,7 +57,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 6
+#serial 7
 
 AU_ALIAS([AC_CXX_HAVE_FREEZE_SSTREAM], [AX_CXX_HAVE_FREEZE_SSTREAM])
 AC_DEFUN([AX_CXX_HAVE_FREEZE_SSTREAM],
@@ -65,20 +65,18 @@ AC_DEFUN([AX_CXX_HAVE_FREEZE_SSTREAM],
 ax_cv_cxx_have_freeze_sstream,
 [AC_REQUIRE([AX_CXX_NAMESPACES])
   AC_REQUIRE([AX_CXX_HAVE_SSTREAM])
-  AC_LANG_SAVE
-  AC_LANG_CPLUSPLUS
-  AC_TRY_COMPILE([#include <sstream>
+  AC_LANG_PUSH([C++])
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sstream>
 #ifdef HAVE_NAMESPACES
 using namespace std;
-#endif],
-[#ifdef HAVE_SSTREAM
+#endif]], [[#ifdef HAVE_SSTREAM
 stringstream message;
 #else
 strstream message;
 #endif
-message << "Hello"; message.freeze(0); return 0;],
-  ax_cv_cxx_have_freeze_sstream=yes, ax_cv_cxx_have_freeze_sstream=no)
-  AC_LANG_RESTORE
+message << "Hello"; message.freeze(0); return 0;]])],
+  [ax_cv_cxx_have_freeze_sstream=yes], [ax_cv_cxx_have_freeze_sstream=no])
+  AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_have_freeze_sstream" = yes; then
    AC_DEFINE(HAVE_FREEZE_SSTREAM,,[define if the compiler has freeze in

--- a/m4/ax_cxx_have_long_long_for_iostream.m4
+++ b/m4/ax_cxx_have_long_long_for_iostream.m4
@@ -60,7 +60,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 6
+#serial 7
 
 AU_ALIAS([AC_CXX_HAVE_LONG_LONG_FOR_IOSTREAM], [AX_CXX_HAVE_LONG_LONG_FOR_IOSTREAM])
 AC_DEFUN([AX_CXX_HAVE_LONG_LONG_FOR_IOSTREAM],
@@ -68,9 +68,8 @@ AC_DEFUN([AX_CXX_HAVE_LONG_LONG_FOR_IOSTREAM],
 ax_cv_cxx_have_ll_for_iostream,
 [AC_REQUIRE([AX_CXX_NAMESPACES])
   AC_REQUIRE([AX_CXX_HAVE_SSTREAM])
-  AC_LANG_SAVE
-  AC_LANG_CPLUSPLUS
-  AC_TRY_COMPILE([#include <iostream>
+  AC_LANG_PUSH([C++])
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <iostream>
 #ifdef HAVE_SSTREAM
 #include <strstream>
 #else
@@ -78,9 +77,9 @@ ax_cv_cxx_have_ll_for_iostream,
 #endif
 #ifdef HAVE_NAMESPACES
 using namespace std;
-#endif],[ ostream str((streambuf *)0); long long l=1; str << l; return 0;],
-  ax_cv_cxx_have_ll_for_iostream=yes, ax_cv_cxx_have_ll_for_iostream=no)
-  AC_LANG_RESTORE
+#endif]], [[ostream str((streambuf *)0); long long l=1; str << l; return 0;]])],
+  [ax_cv_cxx_have_ll_for_iostream=yes], [ax_cv_cxx_have_ll_for_iostream=no])
+  AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_have_ll_for_iostream" = yes; then
    AC_DEFINE(HAVE_LONG_LONG_FOR_IOSTREAM,,[define if the compiler allow long long for [i|o]stream])

--- a/m4/ax_cxx_have_numeric_limits.m4
+++ b/m4/ax_cxx_have_numeric_limits.m4
@@ -20,21 +20,20 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_HAVE_NUMERIC_LIMITS], [AX_CXX_HAVE_NUMERIC_LIMITS])
 AC_DEFUN([AX_CXX_HAVE_NUMERIC_LIMITS],
 [AC_CACHE_CHECK(whether the compiler has numeric_limits<T>,
 ax_cv_cxx_have_numeric_limits,
 [AC_REQUIRE([AX_CXX_NAMESPACES])
- AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
- AC_TRY_COMPILE([#include <limits>
+ AC_LANG_PUSH([C++])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <limits>
 #ifdef HAVE_NAMESPACES
 using namespace std;
-#endif],[double e = numeric_limits<double>::epsilon(); return 0;],
- ax_cv_cxx_have_numeric_limits=yes, ax_cv_cxx_have_numeric_limits=no)
- AC_LANG_RESTORE
+#endif]], [[double e = numeric_limits<double>::epsilon(); return 0;]])],
+ [ax_cv_cxx_have_numeric_limits=yes], [ax_cv_cxx_have_numeric_limits=no])
+ AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_have_numeric_limits" = yes; then
   AC_DEFINE(HAVE_NUMERIC_LIMITS,,[define if the compiler has numeric_limits<T>])

--- a/m4/ax_cxx_have_sstream.m4
+++ b/m4/ax_cxx_have_sstream.m4
@@ -19,21 +19,20 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_HAVE_SSTREAM], [AX_CXX_HAVE_SSTREAM])
 AC_DEFUN([AX_CXX_HAVE_SSTREAM],
 [AC_CACHE_CHECK(whether the compiler has stringstream,
 ax_cv_cxx_have_sstream,
 [AC_REQUIRE([AX_CXX_NAMESPACES])
- AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
- AC_TRY_COMPILE([#include <sstream>
+ AC_LANG_PUSH([C++])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sstream>
 #ifdef HAVE_NAMESPACES
 using namespace std;
-#endif],[stringstream message; message << "Hello"; return 0;],
- ax_cv_cxx_have_sstream=yes, ax_cv_cxx_have_sstream=no)
- AC_LANG_RESTORE
+#endif]], [[stringstream message; message << "Hello"; return 0;]])],
+ [ax_cv_cxx_have_sstream=yes], [ax_cv_cxx_have_sstream=no])
+ AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_have_sstream" = yes; then
   AC_DEFINE(HAVE_SSTREAM,,[define if the compiler has stringstream])

--- a/m4/ax_cxx_have_std.m4
+++ b/m4/ax_cxx_have_std.m4
@@ -21,24 +21,22 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_HAVE_STD], [AX_CXX_HAVE_STD])
 AC_DEFUN([AX_CXX_HAVE_STD],
 [AC_CACHE_CHECK(whether the compiler supports ISO C++ standard library,
 ax_cv_cxx_have_std,
 [AC_REQUIRE([AX_CXX_NAMESPACES])
- AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
- AC_TRY_COMPILE([#include <iostream>
+ AC_LANG_PUSH([C++])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <iostream>
 #include <map>
 #include <iomanip>
 #include <cmath>
 #ifdef HAVE_NAMESPACES
 using namespace std;
-#endif],[return 0;],
- ax_cv_cxx_have_std=yes, ax_cv_cxx_have_std=no)
- AC_LANG_RESTORE
+#endif]], [[return 0;]])],[ax_cv_cxx_have_std=yes],[ax_cv_cxx_have_std=no])
+ AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_have_std" = yes; then
   AC_DEFINE(HAVE_STD,,[define if the compiler supports ISO C++ standard library])

--- a/m4/ax_cxx_have_stl.m4
+++ b/m4/ax_cxx_have_stl.m4
@@ -20,23 +20,22 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_HAVE_STL], [AX_CXX_HAVE_STL])
 AC_DEFUN([AX_CXX_HAVE_STL],
 [AC_CACHE_CHECK(whether the compiler supports Standard Template Library,
 ax_cv_cxx_have_stl,
 [AC_REQUIRE([AX_CXX_NAMESPACES])
- AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
- AC_TRY_COMPILE([#include <list>
+ AC_LANG_PUSH([C++])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <list>
 #include <deque>
 #ifdef HAVE_NAMESPACES
 using namespace std;
-#endif],[list<int> x; x.push_back(5);
-list<int>::iterator iter = x.begin(); if (iter != x.end()) ++iter; return 0;],
- ax_cv_cxx_have_stl=yes, ax_cv_cxx_have_stl=no)
- AC_LANG_RESTORE
+#endif]], [[list<int> x; x.push_back(5);
+list<int>::iterator iter = x.begin(); if (iter != x.end()) ++iter; return 0;]])],
+ [ax_cv_cxx_have_stl=yes], [ax_cv_cxx_have_stl=no])
+ AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_have_stl" = yes; then
   AC_DEFINE(HAVE_STL,,[define if the compiler supports Standard Template Library])

--- a/m4/ax_cxx_have_string_push_back.m4
+++ b/m4/ax_cxx_have_string_push_back.m4
@@ -20,21 +20,20 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_HAVE_STRING_PUSH_BACK], [AX_CXX_HAVE_STRING_PUSH_BACK])
 AC_DEFUN([AX_CXX_HAVE_STRING_PUSH_BACK],
-[AC_CACHE_CHECK(whether the compiler has std::string::push_back (char),
+[AC_CACHE_CHECK([whether the compiler has std::string::push_back (char)],
 ax_cv_cxx_have_string_push_back,
 [AC_REQUIRE([AX_CXX_NAMESPACES])
- AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
- AC_TRY_COMPILE([#include <string>
+ AC_LANG_PUSH([C++])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <string>
 #ifdef HAVE_NAMESPACES
 using namespace std;
-#endif],[string message; message.push_back ('a'); return 0;],
- ax_cv_cxx_have_string_push_back=yes, ax_cv_cxx_have_string_push_back=no)
- AC_LANG_RESTORE
+#endif]], [[string message; message.push_back ('a'); return 0;]])],
+ [ax_cv_cxx_have_string_push_back=yes], [ax_cv_cxx_have_string_push_back=no])
+ AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_have_string_push_back" = yes; then
  AC_DEFINE(HAVE_STRING_PUSH_BACK,,[define if the compiler has the method

--- a/m4/ax_cxx_have_valarray.m4
+++ b/m4/ax_cxx_have_valarray.m4
@@ -20,21 +20,20 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_HAVE_VALARRAY], [AX_CXX_HAVE_VALARRAY])
 AC_DEFUN([AX_CXX_HAVE_VALARRAY],
 [AC_CACHE_CHECK(whether the compiler has valarray<T>,
 ax_cv_cxx_have_valarray,
 [AC_REQUIRE([AX_CXX_NAMESPACES])
- AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
- AC_TRY_COMPILE([#include <valarray>
+ AC_LANG_PUSH([C++])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <valarray>
 #ifdef HAVE_NAMESPACES
 using namespace std;
-#endif],[valarray<float> x(100); return 0;],
- ax_cv_cxx_have_valarray=yes, ax_cv_cxx_have_valarray=no)
- AC_LANG_RESTORE
+#endif]], [[valarray<float> x(100); return 0;]])],
+ [ax_cv_cxx_have_valarray=yes], [ax_cv_cxx_have_valarray=no])
+ AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_have_valarray" = yes; then
   AC_DEFINE(HAVE_VALARRAY,,[define if the compiler has valarray<T>])

--- a/m4/ax_cxx_have_vector_at.m4
+++ b/m4/ax_cxx_have_vector_at.m4
@@ -20,21 +20,20 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_HAVE_VECTOR_AT], [AX_CXX_HAVE_VECTOR_AT])
 AC_DEFUN([AX_CXX_HAVE_VECTOR_AT],
-[AC_CACHE_CHECK(whether the compiler has std::vector::at (std::size_t),
+[AC_CACHE_CHECK([whether the compiler has std::vector::at (std::size_t)],
 ax_cv_cxx_have_vector_at,
 [AC_REQUIRE([AX_CXX_NAMESPACES])
- AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
- AC_TRY_COMPILE([#include <vector>
+ AC_LANG_PUSH([C++])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <vector>
 #ifdef HAVE_NAMESPACES
 using namespace std;
-#endif],[vector<int> v (1); v.at (0); return 0;],
- ax_cv_cxx_have_vector_at=yes, ax_cv_cxx_have_vector_at=no)
- AC_LANG_RESTORE
+#endif]], [[vector<int> v (1); v.at (0); return 0;]])],
+ [ax_cv_cxx_have_vector_at=yes], [ax_cv_cxx_have_vector_at=no])
+ AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_have_vector_at" = yes; then
  AC_DEFINE(HAVE_VECTOR_AT,,[define if the compiler has the method

--- a/m4/ax_cxx_header_pre_stdcxx.m4
+++ b/m4/ax_cxx_header_pre_stdcxx.m4
@@ -19,19 +19,18 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_HEADER_PRE_STDCXX], [AX_CXX_HEADER_PRE_STDCXX])
 AC_DEFUN([AX_CXX_HEADER_PRE_STDCXX], [
   AC_CACHE_CHECK(for pre-ISO C++ include files,
   ax_cv_cxx_pre_stdcxx,
-  [AC_LANG_SAVE
-  AC_LANG_CPLUSPLUS
+  [AC_LANG_PUSH([C++])
   ac_save_CXXFLAGS="$CXXFLAGS"
   CXXFLAGS="$CXXFLAGS -Wno-deprecated"
 
   # Omit defalloc.h, as compilation with newer compilers is problematic.
-  AC_TRY_COMPILE([
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
   #include <new.h>
   #include <iterator.h>
   #include <alloc.h>
@@ -65,10 +64,10 @@ AC_DEFUN([AX_CXX_HEADER_PRE_STDCXX], [
   #include <algo.h>
   #include <queue.h>
   #include <streambuf.h>
-  ],,
-  ax_cv_cxx_pre_stdcxx=yes, ax_cv_cxx_pre_stdcxx=no)
+  ]], [])],
+  [ax_cv_cxx_pre_stdcxx=yes], [ax_cv_cxx_pre_stdcxx=no])
   CXXFLAGS="$ac_save_CXXFLAGS"
-  AC_LANG_RESTORE
+  AC_LANG_POP([C++])
   ])
   if test "$ax_cv_cxx_pre_stdcxx" = yes; then
     AC_DEFINE(PRE_STDCXX_HEADERS,,[Define if pre-ISO C++ header files are present. ])

--- a/m4/ax_cxx_header_stdcxx_0x.m4
+++ b/m4/ax_cxx_header_stdcxx_0x.m4
@@ -19,19 +19,18 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 8
+#serial 9
 
 AU_ALIAS([AC_CXX_HEADER_STDCXX_0X], [AX_CXX_HEADER_STDCXX_0X])
 AC_DEFUN([AX_CXX_HEADER_STDCXX_0X], [
   AC_CACHE_CHECK(for ISO C++ 0x include files,
   ax_cv_cxx_stdcxx_0x,
   [AC_REQUIRE([AC_COMPILE_STDCXX_0X])
-  AC_LANG_SAVE
-  AC_LANG_CPLUSPLUS
+  AC_LANG_PUSH([C++])
   ac_save_CXXFLAGS="$CXXFLAGS"
   CXXFLAGS="$CXXFLAGS -std=gnu++0x"
 
-  AC_TRY_COMPILE([
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
     #include <cassert>
     #include <ccomplex>
     #include <cctype>
@@ -109,9 +108,9 @@ AC_DEFUN([AX_CXX_HEADER_STDCXX_0X], [
     #include <utility>
     #include <valarray>
     #include <vector>
-  ],,
-  ax_cv_cxx_stdcxx_0x=yes, ax_cv_cxx_stdcxx_0x=no)
-  AC_LANG_RESTORE
+  ]], [])],
+  [ax_cv_cxx_stdcxx_0x=yes], [ax_cv_cxx_stdcxx_0x=no])
+  AC_LANG_POP([C++])
   CXXFLAGS="$ac_save_CXXFLAGS"
   ])
   if test "$ax_cv_cxx_stdcxx_0x" = yes; then

--- a/m4/ax_cxx_header_stdcxx_98.m4
+++ b/m4/ax_cxx_header_stdcxx_98.m4
@@ -19,15 +19,14 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_HEADER_STDCXX_98], [AX_CXX_HEADER_STDCXX_98])
 AC_DEFUN([AX_CXX_HEADER_STDCXX_98], [
   AC_CACHE_CHECK(for ISO C++ 98 include files,
   ax_cv_cxx_stdcxx_98,
-  [AC_LANG_SAVE
-  AC_LANG_CPLUSPLUS
-  AC_TRY_COMPILE([
+  [AC_LANG_PUSH([C++])
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
     #include <cassert>
     #include <cctype>
     #include <cerrno>
@@ -77,9 +76,8 @@ AC_DEFUN([AX_CXX_HEADER_STDCXX_98], [
     #include <utility>
     #include <valarray>
     #include <vector>
-  ],,
-  ax_cv_cxx_stdcxx_98=yes, ax_cv_cxx_stdcxx_98=no)
-  AC_LANG_RESTORE
+  ]], [[]])],[ax_cv_cxx_stdcxx_98=yes],[ax_cv_cxx_stdcxx_98=no])
+  AC_LANG_POP([C++])
   ])
   if test "$ax_cv_cxx_stdcxx_98" = yes; then
     AC_DEFINE(STDCXX_98_HEADERS,,[Define if ISO C++ 1998 header files are present. ])

--- a/m4/ax_cxx_header_stdcxx_tr1.m4
+++ b/m4/ax_cxx_header_stdcxx_tr1.m4
@@ -19,15 +19,14 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_HEADER_STDCXX_TR1], [AX_CXX_HEADER_STDCXX_TR1])
 AC_DEFUN([AX_CXX_HEADER_STDCXX_TR1], [
   AC_CACHE_CHECK(for ISO C++ TR1 include files,
   ax_cv_cxx_stdcxx_tr1,
-  [AC_LANG_SAVE
-  AC_LANG_CPLUSPLUS
-  AC_TRY_COMPILE([
+  [AC_LANG_PUSH([C++])
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
   #include <tr1/array>
   #include <tr1/ccomplex>
   #include <tr1/cctype>
@@ -55,9 +54,9 @@ AC_DEFUN([AX_CXX_HEADER_STDCXX_TR1], [
   #include <tr1/unordered_set>
   #include <tr1/unordered_map>
   #include <tr1/utility>
-  ],,
-  ax_cv_cxx_stdcxx_tr1=yes, ax_cv_cxx_stdcxx_tr1=no)
-  AC_LANG_RESTORE
+  ]], [])],
+  [ax_cv_cxx_stdcxx_tr1=yes], [ax_cv_cxx_stdcxx_tr1=no])
+  AC_LANG_POP([C++])
   ])
   if test "$ax_cv_cxx_stdcxx_tr1" = yes; then
     AC_DEFINE(STDCXX_TR1_HEADERS,,[Define if ISO C++ TR1 header files are present. ])

--- a/m4/ax_cxx_header_tr1_unordered_map.m4
+++ b/m4/ax_cxx_header_tr1_unordered_map.m4
@@ -20,17 +20,17 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_HEADER_TR1_UNORDERED_MAP], [AX_CXX_HEADER_TR1_UNORDERED_MAP])
 AC_DEFUN([AX_CXX_HEADER_TR1_UNORDERED_MAP], [
   AC_CACHE_CHECK(for tr1/unordered_map,
   ax_cv_cxx_tr1_unordered_map,
-  [AC_LANG_SAVE
-  AC_LANG_CPLUSPLUS
-  AC_TRY_COMPILE([#include <tr1/unordered_map>], [using std::tr1::unordered_map;],
-  ax_cv_cxx_tr1_unordered_map=yes, ax_cv_cxx_tr1_unordered_map=no)
-  AC_LANG_RESTORE
+  [AC_LANG_PUSH([C++])
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <tr1/unordered_map>]],
+  [[using std::tr1::unordered_map;]])],
+  [ax_cv_cxx_tr1_unordered_map=yes], [ax_cv_cxx_tr1_unordered_map=no])
+  AC_LANG_POP([C++])
   ])
   if test "$ax_cv_cxx_tr1_unordered_map" = yes; then
     AC_DEFINE(HAVE_TR1_UNORDERED_MAP,,[Define if tr1/unordered_map is present. ])

--- a/m4/ax_cxx_header_tr1_unordered_set.m4
+++ b/m4/ax_cxx_header_tr1_unordered_set.m4
@@ -20,17 +20,17 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_HEADER_TR1_UNORDERED_SET], [AX_CXX_HEADER_TR1_UNORDERED_SET])
 AC_DEFUN([AX_CXX_HEADER_TR1_UNORDERED_SET], [
   AC_CACHE_CHECK(for tr1/unordered_set,
   ax_cv_cxx_tr1_unordered_set,
-  [AC_LANG_SAVE
-  AC_LANG_CPLUSPLUS
-  AC_TRY_COMPILE([#include <tr1/unordered_set>], [using std::tr1::unordered_set;],
-  ax_cv_cxx_tr1_unordered_set=yes, ax_cv_cxx_tr1_unordered_set=no)
-  AC_LANG_RESTORE
+  [AC_LANG_PUSH([C++])
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <tr1/unordered_set>]],
+  [[using std::tr1::unordered_set;]])],
+  [ax_cv_cxx_tr1_unordered_set=yes], [ax_cv_cxx_tr1_unordered_set=no])
+  AC_LANG_POP([C++])
   ])
   if test "$ax_cv_cxx_tr1_unordered_set" = yes; then
     AC_DEFINE(HAVE_TR1_UNORDERED_SET,,[Define if tr1/unordered_set is present. ])

--- a/m4/ax_cxx_header_unordered_map.m4
+++ b/m4/ax_cxx_header_unordered_map.m4
@@ -20,21 +20,21 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_HEADER_UNORDERED_MAP], [AX_CXX_HEADER_UNORDERED_MAP])
 AC_DEFUN([AX_CXX_HEADER_UNORDERED_MAP], [
   AC_CACHE_CHECK(for unordered_map,
   ax_cv_cxx_unordered_map,
   [AC_REQUIRE([AC_COMPILE_STDCXX_0X])
-  AC_LANG_SAVE
-  AC_LANG_CPLUSPLUS
+  AC_LANG_PUSH([C++])
   ac_save_CXXFLAGS="$CXXFLAGS"
   CXXFLAGS="$CXXFLAGS -std=gnu++0x"
-  AC_TRY_COMPILE([#include <unordered_map>], [using std::unordered_map;],
-  ax_cv_cxx_unordered_map=yes, ax_cv_cxx_unordered_map=no)
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <unordered_map>]],
+  [[using std::unordered_map;]])],
+  [ax_cv_cxx_unordered_map=yes], [ax_cv_cxx_unordered_map=no])
   CXXFLAGS="$ac_save_CXXFLAGS"
-  AC_LANG_RESTORE
+  AC_LANG_POP([C++])
   ])
   if test "$ax_cv_cxx_unordered_map" = yes; then
     AC_DEFINE(HAVE_UNORDERED_MAP,,[Define if unordered_map is present. ])

--- a/m4/ax_cxx_header_unordered_set.m4
+++ b/m4/ax_cxx_header_unordered_set.m4
@@ -20,21 +20,21 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_HEADER_UNORDERED_SET], [AX_CXX_HEADER_UNORDERED_SET])
 AC_DEFUN([AX_CXX_HEADER_UNORDERED_SET], [
   AC_CACHE_CHECK(for unordered_set,
   ax_cv_cxx_unordered_set,
   [AC_REQUIRE([AC_COMPILE_STDCXX_0X])
-  AC_LANG_SAVE
-  AC_LANG_CPLUSPLUS
+  AC_LANG_PUSH([C++])
   ac_save_CXXFLAGS="$CXXFLAGS"
   CXXFLAGS="$CXXFLAGS -std=gnu++0x"
-  AC_TRY_COMPILE([#include <unordered_set>], [using std::unordered_set;],
-  ax_cv_cxx_unordered_set=yes, ax_cv_cxx_unordered_set=no)
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <unordered_set>]],
+  [[using std::unordered_set;]])],
+  [ax_cv_cxx_unordered_set=yes], [ax_cv_cxx_unordered_set=no])
   CXXFLAGS="$ac_save_CXXFLAGS"
-  AC_LANG_RESTORE
+  AC_LANG_POP([C++])
   ])
   if test "$ax_cv_cxx_unordered_set" = yes; then
     AC_DEFINE(HAVE_UNORDERED_SET,,[Define if unordered_set is present. ])

--- a/m4/ax_cxx_member_constants.m4
+++ b/m4/ax_cxx_member_constants.m4
@@ -20,18 +20,17 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_MEMBER_CONSTANTS], [AX_CXX_MEMBER_CONSTANTS])
 AC_DEFUN([AX_CXX_MEMBER_CONSTANTS],
 [AC_CACHE_CHECK(whether the compiler supports member constants,
 ax_cv_cxx_member_constants,
-[AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
- AC_TRY_COMPILE([class C {public: static const int i = 0;}; const int C::i;],
-[return C::i;],
- ax_cv_cxx_member_constants=yes, ax_cv_cxx_member_constants=no)
- AC_LANG_RESTORE
+[AC_LANG_PUSH([C++])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[class C {public: static const int i = 0;}; const int C::i;]],
+ [[return C::i;]])],
+ [ax_cv_cxx_member_constants=yes], [ax_cv_cxx_member_constants=no])
+ AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_member_constants" = yes; then
   AC_DEFINE(HAVE_MEMBER_CONSTANTS,,[define if the compiler supports member constants])

--- a/m4/ax_cxx_member_templates.m4
+++ b/m4/ax_cxx_member_templates.m4
@@ -20,21 +20,20 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_MEMBER_TEMPLATES], [AX_CXX_MEMBER_TEMPLATES])
 AC_DEFUN([AX_CXX_MEMBER_TEMPLATES],
 [AC_CACHE_CHECK(whether the compiler supports member templates,
 ax_cv_cxx_member_templates,
-[AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
- AC_TRY_COMPILE([
+[AC_LANG_PUSH([C++])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 template<class T, int N> class A
 { public:
   template<int N2> A<T,N> operator=(const A<T,N2>& z) { return A<T,N>(); }
-};],[A<double,4> x; A<double,7> y; x = y; return 0;],
- ax_cv_cxx_member_templates=yes, ax_cv_cxx_member_templates=no)
- AC_LANG_RESTORE
+};]], [[A<double,4> x; A<double,7> y; x = y; return 0;]])],
+ [ax_cv_cxx_member_templates=yes], [ax_cv_cxx_member_templates=no])
+ AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_member_templates" = yes; then
   AC_DEFINE(HAVE_MEMBER_TEMPLATES,,[define if the compiler supports member templates])

--- a/m4/ax_cxx_member_templates_outside_class.m4
+++ b/m4/ax_cxx_member_templates_outside_class.m4
@@ -21,24 +21,23 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_MEMBER_TEMPLATES_OUTSIDE_CLASS], [AX_CXX_MEMBER_TEMPLATES_OUTSIDE_CLASS])
 AC_DEFUN([AX_CXX_MEMBER_TEMPLATES_OUTSIDE_CLASS],
 [AC_CACHE_CHECK(whether the compiler supports member templates outside the class declaration,
 ax_cv_cxx_member_templates_outside_class,
-[AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
- AC_TRY_COMPILE([
+[AC_LANG_PUSH([C++])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 template<class T, int N> class A
 { public :
   template<int N2> A<T,N> operator=(const A<T,N2>& z);
 };
 template<class T, int N> template<int N2>
-A<T,N> A<T,N>::operator=(const A<T,N2>& z){ return A<T,N>(); }],[
-A<double,4> x; A<double,7> y; x = y; return 0;],
- ax_cv_cxx_member_templates_outside_class=yes, ax_cv_cxx_member_templates_outside_class=no)
- AC_LANG_RESTORE
+A<T,N> A<T,N>::operator=(const A<T,N2>& z){ return A<T,N>(); }]], [[
+A<double,4> x; A<double,7> y; x = y; return 0;]])],
+ [ax_cv_cxx_member_templates_outside_class=yes], [ax_cv_cxx_member_templates_outside_class=no])
+ AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_member_templates_outside_class" = yes; then
   AC_DEFINE(HAVE_MEMBER_TEMPLATES_OUTSIDE_CLASS,,

--- a/m4/ax_cxx_mutable.m4
+++ b/m4/ax_cxx_mutable.m4
@@ -22,22 +22,20 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_MUTABLE], [AX_CXX_MUTABLE])
 AC_DEFUN([AX_CXX_MUTABLE],
 [AC_CACHE_CHECK(whether the compiler supports the mutable keyword,
 ax_cv_cxx_mutable,
-[AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
- AC_TRY_COMPILE([
+[AC_LANG_PUSH([C++])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 class A { mutable int i;
           public:
           int f (int n) const { i = n; return i; }
         };
-],[A a; return a.f (1);],
- ax_cv_cxx_mutable=yes, ax_cv_cxx_mutable=no)
- AC_LANG_RESTORE
+]], [[A a; return a.f (1);]])],[ax_cv_cxx_mutable=yes],[ax_cv_cxx_mutable=no])
+ AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_mutable" = yes; then
   AC_DEFINE(HAVE_MUTABLE,,[define if the compiler supports the mutable keyword])

--- a/m4/ax_cxx_namespace_std.m4
+++ b/m4/ax_cxx_namespace_std.m4
@@ -20,18 +20,17 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_NAMESPACE_STD], [AX_CXX_NAMESPACE_STD])
 AC_DEFUN([AX_CXX_NAMESPACE_STD], [
   AC_CACHE_CHECK(if g++ supports namespace std,
   ax_cv_cxx_have_std_namespace,
-  [AC_LANG_SAVE
-  AC_LANG_CPLUSPLUS
-  AC_TRY_COMPILE([#include <iostream>
-                  std::istream& is = std::cin;],,
-  ax_cv_cxx_have_std_namespace=yes, ax_cv_cxx_have_std_namespace=no)
-  AC_LANG_RESTORE
+  [AC_LANG_PUSH([C++])
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <iostream>
+                  std::istream& is = std::cin;]], [])],
+  [ax_cv_cxx_have_std_namespace=yes], [ax_cv_cxx_have_std_namespace=no])
+  AC_LANG_POP([C++])
   ])
   if test "$ax_cv_cxx_have_std_namespace" = yes; then
     AC_DEFINE(HAVE_NAMESPACE_STD,,[Define if g++ supports namespace std. ])

--- a/m4/ax_cxx_new_for_scoping.m4
+++ b/m4/ax_cxx_new_for_scoping.m4
@@ -22,23 +22,22 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_NEW_FOR_SCOPING], [AX_CXX_NEW_FOR_SCOPING])
 AC_DEFUN([AX_CXX_NEW_FOR_SCOPING],
 [AC_CACHE_CHECK(whether the compiler accepts the new for scoping rules,
 ax_cv_cxx_new_for_scoping,
-[AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
- AC_TRY_COMPILE(,[
+[AC_LANG_PUSH([C++])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [[
   int z = 0;
   for (int i = 0; i < 10; ++i)
     z = z + i;
   for (int i = 0; i < 10; ++i)
     z = z - i;
-  return z;],
- ax_cv_cxx_new_for_scoping=yes, ax_cv_cxx_new_for_scoping=no)
- AC_LANG_RESTORE
+  return z;]])],
+ [ax_cv_cxx_new_for_scoping=yes], [ax_cv_cxx_new_for_scoping=no])
+ AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_new_for_scoping" = yes; then
   AC_DEFINE(HAVE_NEW_FOR_SCOPING,,[define if the compiler accepts the new for scoping rules])

--- a/m4/ax_cxx_old_for_scoping.m4
+++ b/m4/ax_cxx_old_for_scoping.m4
@@ -24,17 +24,16 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_OLD_FOR_SCOPING], [AX_CXX_OLD_FOR_SCOPING])
 AC_DEFUN([AX_CXX_OLD_FOR_SCOPING],
 [AC_CACHE_CHECK(whether the compiler accepts the old for scoping rules,
 ax_cv_cxx_old_for_scoping,
-[AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
- AC_TRY_COMPILE(,[int z;for (int i=0; i < 10; ++i)z=z+i;z=i;return z;],
- ax_cv_cxx_old_for_scoping=yes, ax_cv_cxx_old_for_scoping=no)
- AC_LANG_RESTORE
+[AC_LANG_PUSH([C++])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [[int z;for (int i=0; i < 10; ++i)z=z+i;z=i;return z;]])],
+ [ax_cv_cxx_old_for_scoping=yes], [ax_cv_cxx_old_for_scoping=no])
+ AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_old_for_scoping" = yes; then
   AC_DEFINE(HAVE_OLD_FOR_SCOPING,,[define if the compiler accepts the old for scoping rules])

--- a/m4/ax_cxx_partial_ordering.m4
+++ b/m4/ax_cxx_partial_ordering.m4
@@ -20,23 +20,22 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_PARTIAL_ORDERING], [AX_CXX_PARTIAL_ORDERING])
 AC_DEFUN([AX_CXX_PARTIAL_ORDERING],
 [AC_CACHE_CHECK(whether the compiler supports partial ordering,
 ax_cv_cxx_partial_ordering,
-[AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
- AC_TRY_COMPILE([
+[AC_LANG_PUSH([C++])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 template<int N> struct I {};
 template<class T> struct A
 {  int r;
    template<class T1, class T2> int operator() (T1, T2)       { r = 0; return r; }
    template<int N1, int N2>     int operator() (I<N1>, I<N2>) { r = 1; return r; }
-};],[A<float> x, y; I<0> a; I<1> b; return x (a,b) + y (float(), double());],
- ax_cv_cxx_partial_ordering=yes, ax_cv_cxx_partial_ordering=no)
- AC_LANG_RESTORE
+};]], [[A<float> x, y; I<0> a; I<1> b; return x (a,b) + y (float(), double());]])],
+ [ax_cv_cxx_partial_ordering=yes], [ax_cv_cxx_partial_ordering=no])
+ AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_partial_ordering" = yes; then
   AC_DEFINE(HAVE_PARTIAL_ORDERING,,

--- a/m4/ax_cxx_partial_specialization.m4
+++ b/m4/ax_cxx_partial_specialization.m4
@@ -21,21 +21,20 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_PARTIAL_SPECIALIZATION], [AX_CXX_PARTIAL_SPECIALIZATION])
 AC_DEFUN([AX_CXX_PARTIAL_SPECIALIZATION],
 [AC_CACHE_CHECK(whether the compiler supports partial specialization,
 ax_cv_cxx_partial_specialization,
-[AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
- AC_TRY_COMPILE([
+[AC_LANG_PUSH([C++])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 template<class T, int N> class A            { public : enum e { z = 0 }; };
 template<int N>          class A<double, N> { public : enum e { z = 1 }; };
 template<class T>        class A<T, 2>      { public : enum e { z = 2 }; };
-],[return (A<int,3>::z == 0) && (A<double,3>::z == 1) && (A<float,2>::z == 2);],
- ax_cv_cxx_partial_specialization=yes, ax_cv_cxx_partial_specialization=no)
- AC_LANG_RESTORE
+]], [[return (A<int,3>::z == 0) && (A<double,3>::z == 1) && (A<float,2>::z == 2);]])],
+ [ax_cv_cxx_partial_specialization=yes], [ax_cv_cxx_partial_specialization=no])
+ AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_partial_specialization" = yes; then
   AC_DEFINE(HAVE_PARTIAL_SPECIALIZATION,,

--- a/m4/ax_cxx_reinterpret_cast.m4
+++ b/m4/ax_cxx_reinterpret_cast.m4
@@ -21,22 +21,21 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_REINTERPRET_CAST], [AX_CXX_REINTERPRET_CAST])
 AC_DEFUN([AX_CXX_REINTERPRET_CAST],
 [AC_CACHE_CHECK(whether the compiler supports reinterpret_cast<>,
 ax_cv_cxx_reinterpret_cast,
-[AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
- AC_TRY_COMPILE([#include <typeinfo>
+[AC_LANG_PUSH([C++])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <typeinfo>
 class Base { public : Base () {} virtual void f () = 0;};
 class Derived : public Base { public : Derived () {} virtual void f () {} };
 class Unrelated { public : Unrelated () {} };
-int g (Unrelated&) { return 0; }],[
-Derived d;Base& b=d;Unrelated& e=reinterpret_cast<Unrelated&>(b);return g(e);],
- ax_cv_cxx_reinterpret_cast=yes, ax_cv_cxx_reinterpret_cast=no)
- AC_LANG_RESTORE
+int g (Unrelated&) { return 0; }]], [[
+Derived d;Base& b=d;Unrelated& e=reinterpret_cast<Unrelated&>(b);return g(e);]])],
+ [ax_cv_cxx_reinterpret_cast=yes], [ax_cv_cxx_reinterpret_cast=no])
+ AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_reinterpret_cast" = yes; then
   AC_DEFINE(HAVE_REINTERPRET_CAST,,

--- a/m4/ax_cxx_rtti.m4
+++ b/m4/ax_cxx_rtti.m4
@@ -21,15 +21,14 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_RTTI], [AX_CXX_RTTI])
 AC_DEFUN([AX_CXX_RTTI],
 [AC_CACHE_CHECK(whether the compiler supports Run-Time Type Identification,
 ax_cv_cxx_rtti,
-[AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
- AC_TRY_COMPILE([#include <typeinfo>
+[AC_LANG_PUSH([C++])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <typeinfo>
 class Base { public :
              Base () {}
              virtual int f () { return 0; }
@@ -38,12 +37,12 @@ class Derived : public Base { public :
                               Derived () {}
                               virtual int f () { return 1; }
                             };
-],[Derived d;
+]], [[Derived d;
 Base *ptr = &d;
 return typeid (*ptr) == typeid (Derived);
-],
- ax_cv_cxx_rtti=yes, ax_cv_cxx_rtti=no)
- AC_LANG_RESTORE
+]])],
+ [ax_cv_cxx_rtti=yes], [ax_cv_cxx_rtti=no])
+ AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_rtti" = yes; then
   AC_DEFINE(HAVE_RTTI,,

--- a/m4/ax_cxx_static_cast.m4
+++ b/m4/ax_cxx_static_cast.m4
@@ -20,21 +20,20 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_STATIC_CAST], [AX_CXX_STATIC_CAST])
 AC_DEFUN([AX_CXX_STATIC_CAST],
 [AC_CACHE_CHECK(whether the compiler supports static_cast<>,
 ax_cv_cxx_static_cast,
-[AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
- AC_TRY_COMPILE([#include <typeinfo>
+[AC_LANG_PUSH([C++])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <typeinfo>
 class Base { public : Base () {} virtual void f () = 0; };
 class Derived : public Base { public : Derived () {} virtual void f () {} };
-int g (Derived&) { return 0; }],[
-Derived d; Base& b = d; Derived& s = static_cast<Derived&> (b); return g (s);],
- ax_cv_cxx_static_cast=yes, ax_cv_cxx_static_cast=no)
- AC_LANG_RESTORE
+int g (Derived&) { return 0; }]], [[
+Derived d; Base& b = d; Derived& s = static_cast<Derived&> (b); return g (s);]])],
+ [ax_cv_cxx_static_cast=yes], [ax_cv_cxx_static_cast=no])
+ AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_static_cast" = yes; then
   AC_DEFINE(HAVE_STATIC_CAST,,

--- a/m4/ax_cxx_stlport_hashmap.m4
+++ b/m4/ax_cxx_stlport_hashmap.m4
@@ -19,19 +19,18 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_STLPORT_HASHMAP], [AX_CXX_STLPORT_HASHMAP])
 AC_DEFUN([AX_CXX_STLPORT_HASHMAP],[
 AC_CACHE_CHECK(whether the compiler supports std::hash_map,
 ax_cv_cxx_stlport_hashmap,
-[AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
- AC_TRY_COMPILE([#include <hash_map>
-using std::hash_map;],
- [],
- ax_cv_cxx_stlport_hashmap=yes, ax_cv_cxx_stlport_hashmap=no)
- AC_LANG_RESTORE
+[AC_LANG_PUSH([C++])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <hash_map>
+using std::hash_map;]],
+ [])],
+ [ax_cv_cxx_stlport_hashmap=yes], [ax_cv_cxx_stlport_hashmap=no])
+ AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_stlport_hashmap" = yes; then
   AC_DEFINE(HAVE_STLPORT_HASHMAP,,[define if the compiler supports std::hash_map])

--- a/m4/ax_cxx_template_keyword_qualifier.m4
+++ b/m4/ax_cxx_template_keyword_qualifier.m4
@@ -22,15 +22,14 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_TEMPLATE_KEYWORD_QUALIFIER], [AX_CXX_TEMPLATE_KEYWORD_QUALIFIER])
 AC_DEFUN([AX_CXX_TEMPLATE_KEYWORD_QUALIFIER],
 [AC_CACHE_CHECK(whether the compiler supports use of the template keyword as a qualifier,
 ax_cv_cxx_template_keyword_qualifier,
-[AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
- AC_TRY_COMPILE([
+[AC_LANG_PUSH([C++])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
   class X
   {
     public:
@@ -42,9 +41,9 @@ ax_cv_cxx_template_keyword_qualifier,
     p->template member<200>(); // OK: < starts template argument
     T::template static_member<100>(); // OK: < starts explicit qualification
   }
-],[X x; f(&x); return 0;],
- ax_cv_cxx_template_keyword_qualifier=yes, ax_cv_cxx_template_keyword_qualifier=no)
- AC_LANG_RESTORE
+]], [[X x; f(&x); return 0;]])],
+ [ax_cv_cxx_template_keyword_qualifier=yes], [ax_cv_cxx_template_keyword_qualifier=no])
+ AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_template_keyword_qualifier" = yes; then
   AC_DEFINE(HAVE_TEMPLATE_KEYWORD_QUALIFIER,,

--- a/m4/ax_cxx_template_qualified_base_class.m4
+++ b/m4/ax_cxx_template_qualified_base_class.m4
@@ -21,7 +21,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_TEMPLATE_QUALIFIED_BASE_CLASS], [AX_CXX_TEMPLATE_QUALIFIED_BASE_CLASS])
 AC_DEFUN([AX_CXX_TEMPLATE_QUALIFIED_BASE_CLASS],
@@ -29,9 +29,8 @@ AC_DEFUN([AX_CXX_TEMPLATE_QUALIFIED_BASE_CLASS],
 ax_cv_cxx_template_qualified_base_class,
 [AC_REQUIRE([AX_CXX_TYPENAME])
  AC_REQUIRE([AX_CXX_FULL_SPECIALIZATION_SYNTAX])
- AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
- AC_TRY_COMPILE([
+ AC_LANG_PUSH([C++])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #ifndef HAVE_TYPENAME
  #define typename
 #endif
@@ -47,9 +46,9 @@ template<class T> class Weird : public base_trait<T>::base
 { public :
   typedef typename base_trait<T>::base base;
   int g () const { return base::f (); }
-};],[ Weird<float> z; return z.g ();],
- ax_cv_cxx_template_qualified_base_class=yes, ax_cv_cxx_template_qualified_base_class=no)
- AC_LANG_RESTORE
+};]], [[ Weird<float> z; return z.g ();]])],
+ [ax_cv_cxx_template_qualified_base_class=yes], [ax_cv_cxx_template_qualified_base_class=no])
+ AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_template_qualified_base_class" = yes; then
   AC_DEFINE(HAVE_TEMPLATE_QUALIFIED_BASE_CLASS,,

--- a/m4/ax_cxx_template_qualified_return_type.m4
+++ b/m4/ax_cxx_template_qualified_return_type.m4
@@ -21,16 +21,15 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_TEMPLATE_QUALIFIED_RETURN_TYPE], [AX_CXX_TEMPLATE_QUALIFIED_RETURN_TYPE])
 AC_DEFUN([AX_CXX_TEMPLATE_QUALIFIED_RETURN_TYPE],
 [AC_CACHE_CHECK(whether the compiler supports template-qualified return types,
 ax_cv_cxx_template_qualified_return_type,
 [AC_REQUIRE([AX_CXX_TYPENAME])
- AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
- AC_TRY_COMPILE([
+ AC_LANG_PUSH([C++])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #ifndef HAVE_TYPENAME
  #define typename
 #endif
@@ -40,9 +39,9 @@ template<class T> class A { public : A () {} };
 template<class X, class Y>
 A<typename promote_trait<X,Y>::T> operator+ (const A<X>&, const A<Y>&)
 { return A<typename promote_trait<X,Y>::T>(); }
-],[A<int> x; A<float> y; A<float> z = x + y; return 0;],
- ax_cv_cxx_template_qualified_return_type=yes, ax_cv_cxx_template_qualified_return_type=no)
- AC_LANG_RESTORE
+]], [[A<int> x; A<float> y; A<float> z = x + y; return 0;]])],
+ [ax_cv_cxx_template_qualified_return_type=yes], [ax_cv_cxx_template_qualified_return_type=no])
+ AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_template_qualified_return_type" = yes; then
   AC_DEFINE(HAVE_TEMPLATE_QUALIFIED_RETURN_TYPE,,

--- a/m4/ax_cxx_template_scoped_argument_matching.m4
+++ b/m4/ax_cxx_template_scoped_argument_matching.m4
@@ -21,25 +21,24 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_TEMPLATE_SCOPED_ARGUMENT_MATCHING], [AX_CXX_TEMPLATE_SCOPED_ARGUMENT_MATCHING])
 AC_DEFUN([AX_CXX_TEMPLATE_SCOPED_ARGUMENT_MATCHING],
 [AC_CACHE_CHECK(whether the compiler supports function matching with argument types which are template scope-qualified,
 ax_cv_cxx_template_scoped_argument_matching,
 [AC_REQUIRE([AX_CXX_TYPENAME])
- AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
- AC_TRY_COMPILE([
+ AC_LANG_PUSH([C++])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #ifndef HAVE_TYPENAME
  #define typename
 #endif
 template<class X> class A { public : typedef X W; };
 template<class Y> class B {};
 template<class Y> void operator+(B<Y> d1, typename Y::W d2) {}
-],[B<A<float> > z; z + 0.5f; return 0;],
- ax_cv_cxx_template_scoped_argument_matching=yes, ax_cv_cxx_template_scoped_argument_matching=no)
- AC_LANG_RESTORE
+]], [[B<A<float> > z; z + 0.5f; return 0;]])],
+ [ax_cv_cxx_template_scoped_argument_matching=yes], [ax_cv_cxx_template_scoped_argument_matching=no])
+ AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_template_scoped_argument_matching" = yes; then
   AC_DEFINE(HAVE_TEMPLATE_SCOPED_ARGUMENT_MATCHING,,

--- a/m4/ax_cxx_templates_as_template_arguments.m4
+++ b/m4/ax_cxx_templates_as_template_arguments.m4
@@ -21,21 +21,20 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_TEMPLATES_AS_TEMPLATE_ARGUMENTS], [AX_CXX_TEMPLATES_AS_TEMPLATE_ARGUMENTS])
 AC_DEFUN([AX_CXX_TEMPLATES_AS_TEMPLATE_ARGUMENTS],
 [AC_CACHE_CHECK(whether the compiler supports templates as template arguments,
 ax_cv_cxx_templates_as_template_arguments,
-[AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
- AC_TRY_COMPILE([
+[AC_LANG_PUSH([C++])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 template<class T> class allocator { public : allocator() {}; };
 template<class X, template<class Y> class T_alloc>
 class A { public : A() {} private : T_alloc<X> alloc_; };
-],[A<double, allocator> x; return 0;],
- ax_cv_cxx_templates_as_template_arguments=yes, ax_cv_cxx_templates_as_template_arguments=no)
- AC_LANG_RESTORE
+]], [[A<double, allocator> x; return 0;]])],
+ [ax_cv_cxx_templates_as_template_arguments=yes], [ax_cv_cxx_templates_as_template_arguments=no])
+ AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_templates_as_template_arguments" = yes; then
   AC_DEFINE(HAVE_TEMPLATES_AS_TEMPLATE_ARGUMENTS,,

--- a/m4/ax_cxx_typename.m4
+++ b/m4/ax_cxx_typename.m4
@@ -20,18 +20,17 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_TYPENAME], [AX_CXX_TYPENAME])
 AC_DEFUN([AX_CXX_TYPENAME],
 [AC_CACHE_CHECK(whether the compiler recognizes typename,
 ax_cv_cxx_typename,
-[AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
- AC_TRY_COMPILE([template<typename T>class X {public:X(){}};],
-[X<float> z; return 0;],
- ax_cv_cxx_typename=yes, ax_cv_cxx_typename=no)
- AC_LANG_RESTORE
+[AC_LANG_PUSH([C++])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[template<typename T>class X {public:X(){}};]],
+ [[X<float> z; return 0;]])],
+ [ax_cv_cxx_typename=yes], [ax_cv_cxx_typename=no])
+ AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_typename" = yes; then
   AC_DEFINE(HAVE_TYPENAME,,[define if the compiler recognizes typename])

--- a/m4/ax_cxx_use_numtrait.m4
+++ b/m4/ax_cxx_use_numtrait.m4
@@ -21,16 +21,15 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CXX_USE_NUMTRAIT], [AX_CXX_USE_NUMTRAIT])
 AC_DEFUN([AX_CXX_USE_NUMTRAIT],
 [AC_CACHE_CHECK(whether the compiler supports numeric traits promotions,
 ax_cv_cxx_use_numtrait,
 [AC_REQUIRE([AX_CXX_TYPENAME])
- AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
- AC_TRY_COMPILE([
+ AC_LANG_PUSH([C++])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #ifndef HAVE_TYPENAME
  #define typename
 #endif
@@ -39,9 +38,9 @@ template<>                class SumType<char> { public : typedef int T_sumtype; 
 template<class T> class A {};
 template<class T> A<typename SumType<T>::T_sumtype> sum(A<T>)
 { return A<typename SumType<T>::T_sumtype>(); }
-],[A<float> x; sum(x); return 0;],
- ax_cv_cxx_use_numtrait=yes, ax_cv_cxx_use_numtrait=no)
- AC_LANG_RESTORE
+]], [[A<float> x; sum(x); return 0;]])],
+ [ax_cv_cxx_use_numtrait=yes], [ax_cv_cxx_use_numtrait=no])
+ AC_LANG_POP([C++])
 ])
 if test "$ax_cv_cxx_use_numtrait" = yes; then
   AC_DEFINE(HAVE_USE_NUMTRAIT,,[define if the compiler supports numeric traits promotions])

--- a/m4/ax_czmq.m4
+++ b/m4/ax_czmq.m4
@@ -31,7 +31,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 2
+#serial 3
 
 AC_DEFUN([AX_CZMQ], [
     AC_ARG_WITH([czmq], [AS_HELP_STRING([--with-czmq=<prefix>],[CZMQ prefix directory])], [
@@ -45,10 +45,9 @@ AC_DEFUN([AX_CZMQ], [
         LD_FLAGS="$LDFLAGS $CZMQ_LDFLAGS"
         CPPFLAGS="$CPPFLAGS $CZMQ_CPPFLAGS"
 
-        AC_LANG_SAVE
-        AC_LANG_C
+        AC_LANG_PUSH([C])
         AC_CHECK_HEADER(czmq.h, [czmq_h=yes], [czmq_h=no])
-        AC_LANG_RESTORE
+        AC_LANG_POP([C])
 
         if test "$czmq_h" = "yes"; then
             version=ifelse([$1], ,3.0.0,$1)

--- a/m4/ax_lib_metis.m4
+++ b/m4/ax_lib_metis.m4
@@ -32,7 +32,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 10
+#serial 11
 
 AU_ALIAS([IMMDX_LIB_METIS], [AX_LIB_METIS])
 AC_DEFUN([AX_LIB_METIS], [
@@ -84,15 +84,14 @@ AC_DEFUN([AX_LIB_METIS], [
 			CFLAGS="-I$with_metis/include"
 			LDFLAGS="-L$with_metis/lib"
 
-			AC_LANG_SAVE
-			AC_LANG_C
+			AC_LANG_PUSH([C])
 
 			AC_CHECK_LIB(metis, METIS_PartMeshDual,
 				[metis_lib=yes], [metis_lib=yes], [-lm])
 			AC_CHECK_HEADER(metis.h, [metis_h=yes],
 				[metis_h=no], [/* check */])
 
-			AC_LANG_RESTORE
+			AC_LANG_POP([C])
 
 			CFLAGS=$old_CFLAGS
 			LDFLAGS=$old_LDFLAGS

--- a/m4/ax_lib_samtools.m4
+++ b/m4/ax_lib_samtools.m4
@@ -72,7 +72,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 3
+#serial 4
 
 AC_DEFUN([AX_LIB_SAMTOOLS],
 #
@@ -122,11 +122,10 @@ if test -n "${SAMTOOLS_HOME}" ; then
         SAMTOOLS_OLD_CPPFLAGS=$LDFLAGS
         LDFLAGS="$LDFLAGS ${SAMTOOLS_LIBDIR}"
         CPPFLAGS="$CPPFLAGS ${SAMTOOLS_INCDIR}"
-        AC_LANG_SAVE
-        AC_LANG_C
+        AC_LANG_PUSH([C])
         AC_CHECK_HEADER([sam.h], [ac_cv_sam_h=yes], [ac_cv_sam_h=no])
         AC_CHECK_LIB([bam], [sam_open], [ac_cv_libbam=yes], [ac_cv_libbam=no])
-        AC_LANG_RESTORE
+        AC_LANG_POP([C])
         if test "$ac_cv_libbam" = "yes" && test "$ac_cv_sam_h" = "yes" ; then
                 #
                 # If both library and header were found, use them

--- a/m4/ax_lib_tabix.m4
+++ b/m4/ax_lib_tabix.m4
@@ -72,7 +72,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 3
+#serial 4
 
 AC_DEFUN([AX_LIB_TABIX],
 #
@@ -122,11 +122,10 @@ if test -n "${TABIX_HOME}" ; then
         TABIX_OLD_CPPFLAGS=$LDFLAGS
         LDFLAGS="$LDFLAGS ${TABIX_LIBDIR}"
         CPPFLAGS="$CPPFLAGS ${TABIX_INCDIR}"
-        AC_LANG_SAVE
-        AC_LANG_C
+        AC_LANG_PUSH([C])
         AC_CHECK_HEADER([tabix.h], [ac_cv_tabix_h=yes], [ac_cv_tabix_h=no])
         AC_CHECK_LIB([tabix],[ti_open],[ac_cv_libtabix=yes],[ac_cv_libtabix=no])
-        AC_LANG_RESTORE
+        AC_LANG_POP([C])
         if test "$ac_cv_libtabix" = "yes" && \
            test "$ac_cv_tabix_h"  = "yes" ; then
                 #

--- a/m4/ax_zmq.m4
+++ b/m4/ax_zmq.m4
@@ -31,7 +31,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 2
+#serial 3
 
 AC_DEFUN([AX_ZMQ], [
     AC_ARG_WITH([zmq], [AS_HELP_STRING([--with-zmq=<prefix>],[ZMQ prefix directory])], [
@@ -45,10 +45,9 @@ AC_DEFUN([AX_ZMQ], [
         LD_FLAGS="$LDFLAGS $ZMQ_LDFLAGS"
         CPPFLAGS="$CPPFLAGS $ZMQ_CPPFLAGS"
 
-        AC_LANG_SAVE
-        AC_LANG_C
+        AC_LANG_PUSH([C])
         AC_CHECK_HEADER(zmq.h, [zmq_h=yes], [zmq_h=no])
-        AC_LANG_RESTORE
+        AC_LANG_POP([C])
 
         if test "$zmq_h" = "yes"; then
             version=ifelse([$1], ,4.0.0,$1)


### PR DESCRIPTION
Autoconf 2.50 in 2001 made several macros obsolete. These include macros for temporary changing the language - `AC_LANG_SAVE`, `AC_LANG_CPLUSPLUS`, `AC_LANG_C`, and `AC_LANG_RESTORE`. Instead of these the `AC_LANG_PUSH` and `AC_LANG_POP` macros should be used with later Autoconf versions.

`AC_TRY_COMPILE` macros should be replaced with AC_COMPILE_IFELSE.

Refs:
- http://git.savannah.gnu.org/cgit/autoconf.git/tree/NEWS
- https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Language-Choice.html
- https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Obsolete-Macros.html