### PR TITLE
Replace obsolete AC_TRY_COMPILE with AC_COMPILE_IFELSE

### DIFF
--- a/m4/ax_c_declare_block.m4
+++ b/m4/ax_c_declare_block.m4
@@ -61,13 +61,13 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 10
+#serial 11
 
 AC_DEFUN([AX_C_DECLARE_BLOCK],[dnl
 AC_CACHE_CHECK(
  [if C variables must be declared at the beginning of a block],
  ax_cv_c_declare_block,[
- AC_TRY_COMPILE([#include <stdio.h>
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <stdio.h>
  int f() {
    char buffer[1024];
    fgets(buffer, 1024, stdin);
@@ -75,9 +75,9 @@ AC_CACHE_CHECK(
    for (i=0; i < ii; i++) {
      fputc(buffer[i], stdout);
    }
- }],
- [],
- ax_cv_c_declare_block=no, ax_cv_c_declare_block=yes)])
+ }]],
+ [])],
+ [ax_cv_c_declare_block=no], [ax_cv_c_declare_block=yes])])
  if test "$ax_cv_c_declare_block" = yes; then
    AC_DEFINE([DECLARE_BLOCK_NEEDED],[1],
     [if C variables must be declared at the beginning of a block])

--- a/m4/ax_c_long_long.m4
+++ b/m4/ax_c_long_long.m4
@@ -20,7 +20,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 6
+#serial 7
 
 AU_ALIAS([AC_C_LONG_LONG], [AX_C_LONG_LONG])
 AC_DEFUN([AX_C_LONG_LONG],
@@ -28,11 +28,11 @@ AC_DEFUN([AX_C_LONG_LONG],
 [if test "$GCC" = yes; then
   ac_cv_c_long_long=yes
   else
-        AC_TRY_COMPILE(,[long long int i;],
-   ac_cv_c_long_long=yes,
-   ac_cv_c_long_long=no)
-   fi])
-   if test $ac_cv_c_long_long = yes; then
-     AC_DEFINE(HAVE_LONG_LONG, 1, [compiler understands long long])
-   fi
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [[long long int i;]])],
+      [ac_cv_c_long_long=yes],
+      [ac_cv_c_long_long=no])
+  fi])
+  if test $ac_cv_c_long_long = yes; then
+    AC_DEFINE(HAVE_LONG_LONG, 1, [compiler understands long long])
+  fi
 ])

--- a/m4/ax_c_var_func.m4
+++ b/m4/ax_c_var_func.m4
@@ -50,17 +50,18 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 11
+#serial 12
 
 AU_ALIAS([AC_C_VAR_FUNC], [AX_C_VAR_FUNC])
 AC_DEFUN([AX_C_VAR_FUNC],
 [AC_REQUIRE([AC_PROG_CC])
 AC_CACHE_CHECK(whether $CC recognizes __func__, ac_cv_c_var_func,
-AC_TRY_COMPILE(,
-[int main() {
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([],
+[[int main() {
 char *s = __func__;
-}], ac_cv_c_var_func=yes,
-ac_cv_c_var_func=no) )
+}]])],
+[ac_cv_c_var_func=yes],
+[ac_cv_c_var_func=no]))
 if test "x$ac_cv_c_var_func" = xyes; then
    AC_DEFINE(HAVE_FUNC,,[Define if the C compiler supports __func__])
 fi

--- a/m4/ax_cflags_no_writable_strings.m4
+++ b/m4/ax_cflags_no_writable_strings.m4
@@ -35,7 +35,7 @@
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 15
+#serial 16
 
 AC_DEFUN([AX_FLAGS_NO_WRITABLE_STRINGS],[dnl
 AS_VAR_PUSHDEF([FLAGS],[_AC_LANG_PREFIX[]FLAGS])dnl
@@ -58,18 +58,17 @@ in "-pedantic -Werror % -fno-writable-strings -Wwrite-strings" dnl   GCC
    "-fullwarn -use_readonly_const %% ok, its the default" dnl IRIX C
    #
 do FLAGS="$ac_save_[]FLAGS "`echo $ac_arg | sed -e 's,%%.*,,' -e 's,%,,'`
-   AC_TRY_COMPILE([],[return 0;],
-   [VAR=`echo $ac_arg | sed -e 's,.*% *,,'` ; break])
+   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [[return 0;]])],
+   [VAR=`echo $ac_arg | sed -e 's,.*% *,,'` ; break],[])
 done
 case ".$VAR" in
    .|.no|.no,*) ;;
    *) # sanity check - testing strcpy() from string.h
       cp config.log config.tmp
-      AC_TRY_COMPILE([#include <string.h>],[
+      AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <string.h>]], [[
       char test[16];
-      if (strcpy (test, "test")) return 1;],
-      dnl the original did use test -n `$CC testprogram.c`
-      [if test `diff config.log config.tmp | grep -i warning | wc -l` != 0
+      if (strcpy (test, "test")) return 1;]])],[dnl the original did use test -n `$CC testprogram.c`
+      if test `diff config.log config.tmp | grep -i warning | wc -l` != 0
   then VAR="no, suppressed, string.h," ; fi],
       [VAR="no, suppressed, string.h"])
       rm config.tmp

--- a/m4/ax_cflags_strict_prototypes.m4
+++ b/m4/ax_cflags_strict_prototypes.m4
@@ -37,7 +37,7 @@
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 17
+#serial 18
 
 AC_DEFUN([AX_FLAGS_STRICT_PROTOTYPES],[dnl
 AS_VAR_PUSHDEF([FLAGS],[_AC_LANG_PREFIX[]FLAGS])dnl
@@ -54,18 +54,18 @@ in "-pedantic -Werror % -fstrict-prototypes -Wstrict-prototypes" dnl   GCC
    "-pedantic % -Wstrict-prototypes %% no, unsupported" dnl oops
    #
 do FLAGS="$ac_save_[]FLAGS "`echo $ac_arg | sed -e 's,%%.*,,' -e 's,%,,'`
-   AC_TRY_COMPILE([],[return 0;],
-   [VAR=`echo $ac_arg | sed -e 's,.*% *,,'` ; break])
+   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [[return 0;]])],
+   [VAR=`echo $ac_arg | sed -e 's,.*% *,,'` ; break], [])
 done
 case ".$VAR" in
    .|.no|.no,*) ;;
    *) # sanity check with signal() from sys/signal.h
     cp config.log config.tmp
-    AC_TRY_COMPILE([#include <signal.h>],[
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <signal.h>]], [[
     if (signal (SIGINT, SIG_IGN) == SIG_DFL) return 1;
-    if (signal (SIGINT, SIG_IGN) != SIG_DFL) return 2;],
-    dnl the original did use test -n `$CC testprogram.c`
-    [if test `diff config.log config.tmp | grep -i warning | wc -l` != 0
+    if (signal (SIGINT, SIG_IGN) != SIG_DFL) return 2;]])],
+    [dnl the original did use test -n `$CC testprogram.c`
+    if test `diff config.log config.tmp | grep -i warning | wc -l` != 0
 then if test `diff config.log config.tmp | grep -i warning | wc -l` != 1
 then VAR="no, suppressed, signal.h," ; fi ; fi],
     [VAR="no, suppressed, signal.h"])

--- a/m4/ax_check_typedef.m4
+++ b/m4/ax_check_typedef.m4
@@ -26,7 +26,7 @@
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CHECK_TYPEDEF], [AX_CHECK_TYPEDEF])
 AC_DEFUN([AX_CHECK_TYPEDEF_],
@@ -35,10 +35,10 @@ ac_lib_var=`echo $1['_']$2 | sed 'y%./+-%__p_%'`
 AC_CACHE_VAL(ac_cv_lib_$ac_lib_var,
 [ eval "ac_cv_type_$ac_lib_var='not-found'"
   ac_cv_check_typedef_header=`echo ifelse([$2], , stddef.h, $2)`
-  AC_TRY_COMPILE( [#include <$ac_cv_check_typedef_header>],
-	[int x = sizeof($1); x = x;],
-        eval "ac_cv_type_$ac_lib_var=yes" ,
-        eval "ac_cv_type_$ac_lib_var=no" )
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <$ac_cv_check_typedef_header>]],
+    [[int x = sizeof($1); x = x;]])],
+    [eval "ac_cv_type_$ac_lib_var=yes"],
+    [eval "ac_cv_type_$ac_lib_var=no"])
   if test `eval echo '$ac_cv_type_'$ac_lib_var` = "no" ; then
      ifelse([$4], , :, $4)
   else

--- a/m4/ax_compile_check_sizeof.m4
+++ b/m4/ax_compile_check_sizeof.m4
@@ -24,8 +24,8 @@
 #
 #     switch (0) case 0: case 0:;
 #
-#   Thus, the AC_TRY_COMPILE will fail if the currently tried size does not
-#   match.
+#   Thus, the AC_COMPILE_IFELSE will fail if the currently tried size does
+#   not match.
 #
 #   Here is an example skeleton configure.in script, demonstrating the
 #   macro's usage:
@@ -85,7 +85,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_COMPILE_CHECK_SIZEOF], [AX_COMPILE_CHECK_SIZEOF])
 AC_DEFUN([AX_COMPILE_CHECK_SIZEOF],

--- a/m4/ax_create_stdint_h.m4
+++ b/m4/ax_create_stdint_h.m4
@@ -53,7 +53,7 @@
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 20
+#serial 21
 
 AC_DEFUN([AX_CHECK_DATA_MODEL],[
    AC_CHECK_SIZEOF(char)
@@ -152,14 +152,14 @@ AC_CACHE_VAL([ac_cv_header_stdint_t],[
 old_CXXFLAGS="$CXXFLAGS" ; CXXFLAGS=""
 old_CPPFLAGS="$CPPFLAGS" ; CPPFLAGS=""
 old_CFLAGS="$CFLAGS"     ; CFLAGS=""
-AC_TRY_COMPILE([#include <stdint.h>],[int_least32_t v = 0;],
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <stdint.h>]], [[int_least32_t v = 0;]])],
 [ac_cv_stdint_result="(assuming C99 compatible system)"
- ac_cv_header_stdint_t="stdint.h"; ],
-[ac_cv_header_stdint_t=""])
+ ac_cv_header_stdint_t="stdint.h";],
+ [ac_cv_header_stdint_t=""])
 if test "$GCC" = "yes" && test ".$ac_cv_header_stdint_t" = "."; then
 CFLAGS="-std=c99"
-AC_TRY_COMPILE([#include <stdint.h>],[int_least32_t v = 0;],
-[AC_MSG_WARN(your GCC compiler has a defunct stdint.h for its default-mode)])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <stdint.h>]], [[int_least32_t v = 0;]])],
+[AC_MSG_WARN(your GCC compiler has a defunct stdint.h for its default-mode)], [])
 fi
 CXXFLAGS="$old_CXXFLAGS"
 CPPFLAGS="$old_CPPFLAGS"

--- a/m4/ax_cxx_have_koenig_lookup.m4
+++ b/m4/ax_cxx_have_koenig_lookup.m4
@@ -20,14 +20,14 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 8
+#serial 9
 
 AU_ALIAS([MNI_CXX_HAVE_KOENIG_LOOKUP], [AX_CXX_HAVE_KOENIG_LOOKUP])
 AC_DEFUN([AX_CXX_HAVE_KOENIG_LOOKUP],
     [AC_CACHE_CHECK(whether the compiler implements Koenig lookup,
                     ax_cv_cxx_have_koenig_lookup,
                     [AC_LANG_PUSH(C++)
-                     AC_TRY_COMPILE([
+                     AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
     namespace N1 {
         class C {};
         void f1(const C& c) {}
@@ -40,9 +40,9 @@ AC_DEFUN([AX_CXX_HAVE_KOENIG_LOOKUP],
                        // otherwise this will fail to compile.
         }
     }
-    ],[],
-                     ax_cv_cxx_have_koenig_lookup=yes,
-                     ax_cv_cxx_have_koenig_lookup=no)
+    ]], [])],
+                    [ax_cv_cxx_have_koenig_lookup=yes],
+                    [ax_cv_cxx_have_koenig_lookup=no])
                      AC_LANG_POP])
     if test "$ax_cv_cxx_have_koenig_lookup" = yes; then
         AC_DEFINE(CXX_HAVE_KOENIG_LOOKUP,1,

--- a/m4/ax_decl_wchar_max.m4
+++ b/m4/ax_decl_wchar_max.m4
@@ -22,16 +22,16 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([VL_DECL_WCHAR_MAX], [AX_DECL_WCHAR_MAX])
 AC_DEFUN([AX_DECL_WCHAR_MAX], [
   AC_CACHE_CHECK([whether WCHAR_MAX is defined], ax_cv_decl_wchar_max, [
-    AC_TRY_COMPILE([
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #ifdef HAVE_WCHAR_H
 #include <wchar.h>
 #endif
-],[WCHAR_MAX],[ax_cv_decl_wchar_max="yes"],[ax_cv_decl_wchar_max="no"])])
+]], [[WCHAR_MAX]])], [ax_cv_decl_wchar_max="yes"], [ax_cv_decl_wchar_max="no"])])
   if test $ax_cv_decl_wchar_max = "no"; then
     AX_CHECK_SIGN([wchar_t],
       [ wc_signed="yes"

--- a/m4/ax_func_mkdir.m4
+++ b/m4/ax_func_mkdir.m4
@@ -58,19 +58,19 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 5
+#serial 6
 
 AU_ALIAS([AC_FUNC_MKDIR], [AX_FUNC_MKDIR])
 AC_DEFUN([AX_FUNC_MKDIR],
 [AC_CHECK_FUNCS([mkdir _mkdir])
 AC_CACHE_CHECK([whether mkdir takes one argument],
                [ac_cv_mkdir_takes_one_arg],
-[AC_TRY_COMPILE([
+[AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #include <sys/stat.h>
 #if HAVE_UNISTD_H
 #  include <unistd.h>
 #endif
-], [mkdir (".");],
+]], [[mkdir (".");]])],
 [ac_cv_mkdir_takes_one_arg=yes], [ac_cv_mkdir_takes_one_arg=no])])
 if test x"$ac_cv_mkdir_takes_one_arg" = xyes; then
   AC_DEFINE([MKDIR_TAKES_ONE_ARG], 1,
@@ -91,7 +91,7 @@ dnl |  may prototype it in dir.h and dirent.h, for instance).
 dnl |
 dnl |Alexandre:
 dnl |  Would it be sufficient to check for these headers and #include
-dnl |  them in the AC_TRY_COMPILE block?  (and is AC_HEADER_DIRENT
+dnl |  them in the AC_COMPILE_IFELSE block?  (and is AC_HEADER_DIRENT
 dnl |  suitable for this?)
 dnl |
 dnl |Thomas:

--- a/m4/ax_gcc_const_call.m4
+++ b/m4/ax_gcc_const_call.m4
@@ -20,16 +20,16 @@
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 9
+#serial 10
 
 AC_DEFUN([AX_GCC_CONST_CALL],[dnl
 AC_CACHE_CHECK(
  [whether the compiler supports function __attribute__((__const__))],
  ax_cv_gcc_const_call,[
- AC_TRY_COMPILE([__attribute__((__const__))
- int f(int i) { return i; }],
- [],
- ax_cv_gcc_const_call=yes, ax_cv_gcc_const_call=no)])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[__attribute__((__const__))
+ int f(int i) { return i; }]],
+ [])],
+ [ax_cv_gcc_const_call=yes], [ax_cv_gcc_const_call=no])])
  if test "$ax_cv_gcc_const_call" = yes; then
    AC_DEFINE([GCC_CONST_CALL],[__attribute__((__const__))],
     [most gcc compilers know a function __attribute__((__const__))])

--- a/m4/ax_gcc_malloc_call.m4
+++ b/m4/ax_gcc_malloc_call.m4
@@ -20,16 +20,16 @@
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 9
+#serial 10
 
 AC_DEFUN([AX_GCC_MALLOC_CALL],[dnl
 AC_CACHE_CHECK(
  [whether the compiler supports function __attribute__((__malloc__))],
  ax_cv_gcc_malloc_call,[
- AC_TRY_COMPILE([__attribute__((__malloc__))
- int f(int i) { return i; }],
- [],
- ax_cv_gcc_malloc_call=yes, ax_cv_gcc_malloc_call=no)])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[__attribute__((__malloc__))
+ int f(int i) { return i; }]],
+ [])],
+ [ax_cv_gcc_malloc_call=yes], [ax_cv_gcc_malloc_call=no])])
  if test "$ax_cv_gcc_malloc_call" = yes; then
    AC_DEFINE([GCC_MALLOC_CALL],[__attribute__((__malloc__))],
     [most gcc compilers know a function __attribute__((__malloc__))])

--- a/m4/ax_gcc_warn_unused_result.m4
+++ b/m4/ax_gcc_warn_unused_result.m4
@@ -20,16 +20,16 @@
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 9
+#serial 10
 
 AC_DEFUN([AX_GCC_WARN_UNUSED_RESULT],[dnl
 AC_CACHE_CHECK(
  [whether the compiler supports function __attribute__((__warn_unused_result__))],
  ax_cv_gcc_warn_unused_result,[
- AC_TRY_COMPILE([__attribute__((__warn_unused_result__))
- int f(int i) { return i; }],
- [],
- ax_cv_gcc_warn_unused_result=yes, ax_cv_gcc_warn_unused_result=no)])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[__attribute__((__warn_unused_result__))
+ int f(int i) { return i; }]],
+ [])],
+ [ax_cv_gcc_warn_unused_result=yes], [ax_cv_gcc_warn_unused_result=no])])
  if test "$ax_cv_gcc_warn_unused_result" = yes; then
    AC_DEFINE([GCC_WARN_UNUSED_RESULT],[__attribute__((__warn_unused_result__))],
     [most gcc compilers know a function __attribute__((__warn_unused_result__))])

--- a/m4/ax_struct_semun.m4
+++ b/m4/ax_struct_semun.m4
@@ -26,21 +26,20 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 8
+#serial 9
 
 AU_ALIAS([ETR_STRUCT_SEMUN], [AX_STRUCT_SEMUN])
 AC_DEFUN([AX_STRUCT_SEMUN],
 [
 AC_CACHE_CHECK([for struct semun], ac_cv_struct_semun, [
-        AC_TRY_COMPILE(
-                [
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
                         #include <sys/types.h>
                         #include <sys/ipc.h>
                         #include <sys/sem.h>
-                ],
-                [ struct semun s; ],
-                ac_cv_struct_semun=yes,
-                ac_cv_struct_semun=no)
+                ]],
+                [[struct semun s;]])],
+                [ac_cv_struct_semun=yes],
+                [ac_cv_struct_semun=no])
 ])
 
         if test x"$ac_cv_struct_semun" = "xyes"

--- a/m4/ax_sysv_ipc.m4
+++ b/m4/ax_sysv_ipc.m4
@@ -21,20 +21,19 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 8
+#serial 9
 
 AU_ALIAS([ETR_SYSV_IPC], [AX_SYSV_IPC])
 AC_DEFUN([AX_SYSV_IPC],
 [
 AC_CACHE_CHECK([for System V IPC headers], ac_cv_sysv_ipc, [
-        AC_TRY_COMPILE(
-                [
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
                         #include <sys/types.h>
                         #include <sys/ipc.h>
                         #include <sys/msg.h>
                         #include <sys/sem.h>
                         #include <sys/shm.h>
-                ],, ac_cv_sysv_ipc=yes, ac_cv_sysv_ipc=no)
+                ]], [])], [ac_cv_sysv_ipc=yes], [ac_cv_sysv_ipc=no])
 ])
 
         if test x"$ac_cv_sysv_ipc" = "xyes"

--- a/m4/ax_type_socklen_t.m4
+++ b/m4/ax_type_socklen_t.m4
@@ -42,18 +42,16 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([TYPE_SOCKLEN_T], [AX_TYPE_SOCKLEN_T])
 AC_DEFUN([AX_TYPE_SOCKLEN_T],
-[AC_CACHE_CHECK([for socklen_t], ac_cv_ax_type_socklen_t,
-[
-  AC_TRY_COMPILE(
-  [#include <sys/types.h>
-   #include <sys/socket.h>],
-  [socklen_t len = (socklen_t) 42; return (!len);],
-  ac_cv_ax_type_socklen_t=yes,
-  ac_cv_ax_type_socklen_t=no)
+[AC_CACHE_CHECK([for socklen_t], [ac_cv_ax_type_socklen_t],
+[AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/types.h>
+  #include <sys/socket.h>]],
+  [[socklen_t len = (socklen_t) 42; return (!len);]])],
+  [ac_cv_ax_type_socklen_t=yes],
+  [ac_cv_ax_type_socklen_t=no])
 ])
   if test $ac_cv_ax_type_socklen_t != yes; then
     AC_DEFINE(socklen_t, int, [Substitute for socklen_t])


### PR DESCRIPTION
Autoconf made several macros obsolete including the `AC_TRY_COMPILE` in 2000 and since Autoconf 2.50:
http://git.savannah.gnu.org/cgit/autoconf.git/tree/ChangeLog.2

These macros should be replaced with the current `AC_COMPILE_IFELSE` instead.

This patch was created with the help of autoupdate script.

Refs:
- https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Obsolete-Macros.html
- https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/AC_005fACT_005fIFELSE-vs-AC_005fTRY_005fACT.html