### PR TITLE
Replace obsolete AC_HELP_STRING with AS_HELP_STRING

### DIFF
--- a/m4/ax_lib_gdal.m4
+++ b/m4/ax_lib_gdal.m4
@@ -39,14 +39,14 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 4
+#serial 5
 
 AC_DEFUN([AX_LIB_GDAL],
 [
     dnl If gdal-config path is not given in ---with-gdal option,
     dnl check if it is present in the system anyway
     AC_ARG_WITH([gdal],
-        AC_HELP_STRING([--with-gdal=@<:@ARG@:>@],
+        AS_HELP_STRING([--with-gdal=@<:@ARG@:>@],
             [Specify full path to gdal-config script]),
         [ac_gdal_config_path=$withval],
         [gdal_config_system=check])
@@ -141,7 +141,7 @@ AC_DEFUN([AX_LIB_GDAL],
             AC_MSG_RESULT([yes])
         else
             AC_MSG_RESULT([no])
-	    AC_MSG_ERROR([GDAL $GDAL_VERSION found, but required version is $gdal_version_req])
+            AC_MSG_ERROR([GDAL $GDAL_VERSION found, but required version is $gdal_version_req])
         fi
     fi
 

--- a/m4/ax_lib_libkml.m4
+++ b/m4/ax_lib_libkml.m4
@@ -42,12 +42,12 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 2
+#serial 3
 
 AC_DEFUN([AX_LIB_LIBKML],
 [
     AC_ARG_WITH([libkml],
-        AC_HELP_STRING([--with-libkml=@<:@ARG@:>@],
+        AS_HELP_STRING([--with-libkml=@<:@ARG@:>@],
             [use Google libkml from given prefix (ARG=path); check standard prefixes (ARG=yes); disable (ARG=no)]
         ),
         [
@@ -81,14 +81,14 @@ AC_DEFUN([AX_LIB_LIBKML],
     )
 
     AC_ARG_WITH([libkml-inc],
-        AC_HELP_STRING([--with-libkml-inc=@<:@DIR@:>@],
+        AS_HELP_STRING([--with-libkml-inc=@<:@DIR@:>@],
             [path to Google libkml headers]
         ),
         [libkml_include_dir="$withval"],
         [libkml_include_dir=""]
     )
     AC_ARG_WITH([libkml-lib],
-        AC_HELP_STRING([--with-libkml-lib=@<:@ARG@:>@],
+        AS_HELP_STRING([--with-libkml-lib=@<:@ARG@:>@],
             [link options for Google libkml libraries]
         ),
         [libkml_lib_flags="$withval"],


### PR DESCRIPTION
Autoconf made several macros obsolete including `AC_HELP_STRING` somewhere in 2003 in Autoconf 2.59 version. Macro should be replaced with `AS_HELP_STRING`.