### PR TITLE
Identify xlc from version 16 on as `ibm` and not as `clang`.

### DIFF
--- a/m4/ax_compiler_vendor.m4
+++ b/m4/ax_compiler_vendor.m4
@@ -51,7 +51,7 @@ AC_DEFUN([AX_COMPILER_VENDOR],
   dnl Please add if possible support to ax_compiler_version.m4
   [# note: don't check for gcc first since some other compilers define __GNUC__
   vendors="intel:     __ICC,__ECC,__INTEL_COMPILER
-           ibm:       __xlc__,__xlC__,__IBMC__,__IBMCPP__
+           ibm:       __xlc__,__xlC__,__IBMC__,__IBMCPP__,__ibmxl__
            pathscale: __PATHCC__,__PATHSCALE__
            clang:     __clang__
            cray:      _CRAYC

--- a/m4/ax_compiler_vendor.m4
+++ b/m4/ax_compiler_vendor.m4
@@ -44,7 +44,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 17
+#serial 18
 
 AC_DEFUN([AX_COMPILER_VENDOR],
 [AC_CACHE_CHECK([for _AC_LANG compiler vendor], ax_cv_[]_AC_LANG_ABBREV[]_compiler_vendor,

--- a/m4/ax_compiler_vendor.m4
+++ b/m4/ax_compiler_vendor.m4
@@ -44,7 +44,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 18
+#serial 20
 
 AC_DEFUN([AX_COMPILER_VENDOR],
 [AC_CACHE_CHECK([for _AC_LANG compiler vendor], ax_cv_[]_AC_LANG_ABBREV[]_compiler_vendor,


### PR DESCRIPTION
xlc from version 16 on does neither define __xlc__, __xlC__, __IBMC__, nor __IBMCPP__ by default. Thus, it does not identify as vendor ibm but as clang. It does define __ibmxl__, though. Adding this macro to the list of ibm macros identifies xlc as ibm again.