### PR TITLE
ax_check_gnu_make: Fix setting of ifGNUmake and ifnGNUmake.

### DIFF
--- a/m4/ax_check_gnu_make.m4
+++ b/m4/ax_check_gnu_make.m4
@@ -87,7 +87,7 @@ dnl Search all the common names for GNU make
     done ;])
 dnl If there was a GNU version, then set @ifGNUmake@ to the empty string, '#' otherwise
   AS_VAR_IF([_cv_gnu_make_command], [""], [AS_VAR_SET([ifGNUmake], ["#"])],   [AS_VAR_SET([ifGNUmake], [""])])
-  AS_VAR_IF([_cv_gnu_make_command], [""], [AS_VAR_SET([ifnGNUmake], [""])],   [AS_VAR_SET([ifGNUmake], ["#"])])
+  AS_VAR_IF([_cv_gnu_make_command], [""], [AS_VAR_SET([ifnGNUmake], [""])],   [AS_VAR_SET([ifnGNUmake], ["#"])])
   AS_VAR_IF([_cv_gnu_make_command], [""], [AS_UNSET(ax_cv_gnu_make_command)], [AS_VAR_SET([ax_cv_gnu_make_command], [${_cv_gnu_make_command}])])
   AS_VAR_IF([_cv_gnu_make_command], [""],[$2],[$1])
   AC_SUBST([ifGNUmake])


### PR DESCRIPTION
The addition of support for ifnGNUmake introduced a bug that made
ifGNUmake be set to "#" in the case GNU Make is detected.

Signed-off-by: Ignacy Gawędzki <ignacy.gawedzki@green-communications.fr>