### PR TITLE
ax_code_coverage: fix self-referencing variable error in distcheck

### DIFF
--- a/m4/ax_code_coverage.m4
+++ b/m4/ax_code_coverage.m4
@@ -74,7 +74,7 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-#serial 32
+#serial 33
 
 m4_define(_AX_CODE_COVERAGE_RULES,[
 AX_ADD_AM_MACRO_STATIC([
@@ -175,7 +175,7 @@ code-coverage-clean:
 
 code-coverage-dist-clean:
 
-A][M_DISTCHECK_CONFIGURE_FLAGS = \$(A][M_DISTCHECK_CONFIGURE_FLAGS) --disable-code-coverage
+A][M_DISTCHECK_CONFIGURE_FLAGS := \$(A][M_DISTCHECK_CONFIGURE_FLAGS) --disable-code-coverage
  else # ifneq (\$(abs_builddir), \$(abs_top_builddir))
 check-code-coverage:
 


### PR DESCRIPTION
Consider the following minimal example:

**`configure.ac`**
```
AC_INIT([package], [version])
AM_INIT_AUTOMAKE([foreign])
AC_CONFIG_FILES([Makefile])
AX_CODE_COVERAGE
AC_OUTPUT
```
**`Makefile.am`**
```
include $(top_srcdir)/aminclude_static.am
clean-local: code-coverage-clean
distclean-local: code-coverage-dist-clean
```

When using `make distcheck` with `--enable-code-coverage`, it fails with the following error:
```
$ autoreconf --install
[...]
$ ./configure --enable-code-coverage
[...]
$ make distcheck
[...]
Makefile:241: *** Recursive variable 'AM_DISTCHECK_CONFIGURE_FLAGS' references itself (eventually).  Stop.
```

This can be fixed by using a simply-expanded variable instead, as described in the [`make` documentation](https://www.gnu.org/software/make/manual/html_node/Error-Messages.html).

The error originally appeared in https://github.com/tpm2-software/tpm2-abrmd/pull/574.