### PR TITLE
ax_have_qt.m4: Fix not getting variables from the generated Makefile on Windows

### DIFF
--- a/m4/ax_have_qt.m4
+++ b/m4/ax_have_qt.m4
@@ -54,7 +54,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 15
+#serial 16
 
 AU_ALIAS([BNV_HAVE_QT], [AX_HAVE_QT])
 AC_DEFUN([AX_HAVE_QT],
@@ -73,6 +73,10 @@ AC_DEFUN([AX_HAVE_QT],
     am_have_qt_makefile=`mktemp`
     # http://qt-project.org/doc/qt-5/qmake-variable-reference.html#qt
     cat > $am_have_qt_pro << EOF
+win32 {
+    CONFIG -= debug_and_release
+    CONFIG += release
+}
 qtHaveModule(axcontainer):       QT += axcontainer
 qtHaveModule(axserver):          QT += axserver
 qtHaveModule(concurrent):        QT += concurrent


### PR DESCRIPTION
Under Windows, the generated Makefile does not contain the required
information by default, because it is contained in other Makefiles
for the Release and Debug build variants. It is therefore necessary
to use only one build variant.

This issue has been detected on cross compiling gwenhywfar.