### PR TITLE
ax_boost_base: fix libsubdirs preference for MIPS64

### DIFF
--- a/m4/ax_boost_base.m4
+++ b/m4/ax_boost_base.m4
@@ -33,7 +33,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 45
+#serial 46
 
 # example boost program (need to pass version)
 m4_define([_AX_BOOST_BASE_PROGRAM],
@@ -113,6 +113,7 @@ AC_DEFUN([_AX_BOOST_BASE_RUNDETECT],[
     dnl are found, e.g. when only header-only libraries are installed!
     AS_CASE([${host_cpu}],
       [x86_64],[libsubdirs="lib64 libx32 lib lib64"],
+      [mips64],[libsubdirs="lib64 lib32 lib lib64"],
       [ppc64|powerpc64|s390x|sparc64|aarch64|ppc64le|powerpc64le|riscv64],[libsubdirs="lib64 lib lib64"],
       [libsubdirs="lib"]
     )


### PR DESCRIPTION
Currently there're 3 well-known ABIs in use on MIPS64 systems, with
the respective libdir as follows:

* n64: `lib64`,
* n32: `lib32`,
* o32: `lib`.

Probe all three of them.