### PR TITLE
ax_{blas,lapack}: add macOS dynamic library suffix (`.dylib`) globs to `with_{blas,lapack}` case statements  

### DIFF
--- a/m4/ax_blas.m4
+++ b/m4/ax_blas.m4
@@ -36,6 +36,7 @@
 # LICENSE
 #
 #   Copyright (c) 2008 Steven G. Johnson <stevenj@alum.mit.edu>
+#   Copyright (c) 2019 Geoffrey M. Oxberry <goxberry@gmail.com>
 #
 #   This program is free software: you can redistribute it and/or modify it
 #   under the terms of the GNU General Public License as published by the
@@ -63,7 +64,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 16
+#serial 17
 
 AU_ALIAS([ACX_BLAS], [AX_BLAS])
 AC_DEFUN([AX_BLAS], [
@@ -77,7 +78,9 @@ AC_ARG_WITH(blas,
 case $with_blas in
 	yes | "") ;;
 	no) ax_blas_ok=disable ;;
-	-* | */* | *.a | *.so | *.so.* | *.o) BLAS_LIBS="$with_blas" ;;
+	-* | */* | *.a | *.so | *.so.* | *.dylib | *.dylib.* | *.o)
+		BLAS_LIBS="$with_blas"
+	;;
 	*) BLAS_LIBS="-l$with_blas" ;;
 esac
 

--- a/m4/ax_lapack.m4
+++ b/m4/ax_lapack.m4
@@ -37,6 +37,7 @@
 # LICENSE
 #
 #   Copyright (c) 2009 Steven G. Johnson <stevenj@alum.mit.edu>
+#   Copyright (c) 2019 Geoffrey M. Oxberry <goxberry@gmail.com>
 #
 #   This program is free software: you can redistribute it and/or modify it
 #   under the terms of the GNU General Public License as published by the
@@ -64,7 +65,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 9
+#serial 10
 
 AU_ALIAS([ACX_LAPACK], [AX_LAPACK])
 AC_DEFUN([AX_LAPACK], [
@@ -76,7 +77,9 @@ AC_ARG_WITH(lapack,
 case $with_lapack in
         yes | "") ;;
         no) ax_lapack_ok=disable ;;
-        -* | */* | *.a | *.so | *.so.* | *.o) LAPACK_LIBS="$with_lapack" ;;
+        -* | */* | *.a | *.so | *.so.* | *.dylib | *.dylib.* | *.o)
+                 LAPACK_LIBS="$with_lapack"
+        ;;
         *) LAPACK_LIBS="-l$with_lapack" ;;
 esac
 


### PR DESCRIPTION
The `ax_blas` and `ax_lapack` macros use `case $with_blas` and `case $with_lapack` statements to check for a number of library suffixes via globs. Prior to this PR, these suffixes did not include the globs `*.dylib` and `*.dylib.*`, both of which check for macOS suffixes used to denote shared libraries. This PR adds globs corresponding to these macOS shared library suffixes.