### PR TITLE
BUG FIX: ax_r_package: Fixing a _R_CHECK_LENGTH_1_CONDITION_=true bug

### DIFF
--- a/m4/ax_r_package.m4
+++ b/m4/ax_r_package.m4
@@ -22,7 +22,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 1
+#serial 2
 
 AC_DEFUN([AX_R_PACKAGE], [
     pushdef([PKG],$1)
@@ -40,7 +40,7 @@ AC_DEFUN([AX_R_PACKAGE], [
 
     AC_MSG_CHECKING([R package PKG VERSION])
 
-    TEST=$( $R --silent --vanilla -e 'if(is.na(packageDescription("PKG"))) stop("not found")' 2>/dev/null )
+    TEST=$( $R --silent --vanilla -e 'if(system.file(package="PKG") == "") stop("not found")' 2>/dev/null )
     AS_IF([test $? -eq 0], [], [
       AC_MSG_RESULT([no])
       AC_MSG_ERROR([R package PKG not found.])


### PR DESCRIPTION
If a package exists, the test for its existence produces an error with `_R_CHECK_LENGTH_1_CONDITION_=true` (introduced in R 3.4.0), e.g.

```sh
$ _R_CHECK_LENGTH_1_CONDITION_=true R --silent --vanilla -e 'if(is.na(packageDescription("BH"))) stop("not found")'
> if(is.na(packageDescription("BH"))) stop("not found")
Error in if (is.na(packageDescription("BH"))) stop("not found") :
  the condition has length > 1
Execution halted
```

This is because `is.na(packageDescription("BH"))` resolved to a logical vector of 15(!) `FALSE` values when package 'BH' is installed.  If it is not installed, then it resolves to `TRUE`.