### PR TITLE
Improve Boost library error messages

### DIFF
--- a/m4/ax_boost_asio.m4
+++ b/m4/ax_boost_asio.m4
@@ -30,7 +30,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 17
+#serial 18
 
 AC_DEFUN([AX_BOOST_ASIO],
 [
@@ -97,7 +97,7 @@ AC_DEFUN([AX_BOOST_ASIO],
 
             fi
             if test "x$ax_lib" = "x"; then
-                AC_MSG_ERROR(Could not find a version of the library!)
+                AC_MSG_ERROR(Could not find a version of the Boost::Asio library!)
             fi
 			if test "x$link_asio" = "xno"; then
 				AC_MSG_ERROR(Could not link against $ax_lib !)

--- a/m4/ax_boost_chrono.m4
+++ b/m4/ax_boost_chrono.m4
@@ -29,7 +29,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 4
+#serial 5
 
 AC_DEFUN([AX_BOOST_CHRONO],
 [
@@ -105,7 +105,7 @@ AC_DEFUN([AX_BOOST_CHRONO],
 
             fi
             if test "x$ax_lib" = "x"; then
-                AC_MSG_ERROR(Could not find a version of the library!)
+                AC_MSG_ERROR(Could not find a version of the Boost::Chrono library!)
             fi
 			if test "x$link_chrono" = "xno"; then
 				AC_MSG_ERROR(Could not link against $ax_lib !)

--- a/m4/ax_boost_context.m4
+++ b/m4/ax_boost_context.m4
@@ -31,7 +31,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 2
+#serial 3
 
 AC_DEFUN([AX_BOOST_CONTEXT],
 [
@@ -108,7 +108,7 @@ AC_DEFUN([AX_BOOST_CONTEXT],
 			fi
 
 			if test "x$ax_lib" = "x"; then
-				AC_MSG_ERROR(Could not find a version of the library!)
+				AC_MSG_ERROR(Could not find a version of the Boost::Context library!)
 			fi
 
 			if test "x$link_context" = "xno"; then

--- a/m4/ax_boost_coroutine.m4
+++ b/m4/ax_boost_coroutine.m4
@@ -31,7 +31,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 2
+#serial 3
 
 AC_DEFUN([AX_BOOST_COROUTINE],
 [
@@ -108,7 +108,7 @@ AC_DEFUN([AX_BOOST_COROUTINE],
 			fi
 
 			if test "x$ax_lib" = "x"; then
-				AC_MSG_ERROR(Could not find a version of the library!)
+				AC_MSG_ERROR(Could not find a version of the Boost::Coroutine library!)
 			fi
 
 			if test "x$link_coroutine" = "xno"; then

--- a/m4/ax_boost_date_time.m4
+++ b/m4/ax_boost_date_time.m4
@@ -30,7 +30,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 22
+#serial 23
 
 AC_DEFUN([AX_BOOST_DATE_TIME],
 [
@@ -100,7 +100,7 @@ AC_DEFUN([AX_BOOST_DATE_TIME],
 
             fi
             if test "x$ax_lib" = "x"; then
-                AC_MSG_ERROR(Could not find a version of the library!)
+                AC_MSG_ERROR(Could not find a version of the Boost::Date_Time library!)
             fi
 			if test "x$link_date_time" != "xyes"; then
 				AC_MSG_ERROR(Could not link against $ax_lib !)

--- a/m4/ax_boost_filesystem.m4
+++ b/m4/ax_boost_filesystem.m4
@@ -31,7 +31,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 27
+#serial 28
 
 AC_DEFUN([AX_BOOST_FILESYSTEM],
 [
@@ -104,7 +104,7 @@ AC_DEFUN([AX_BOOST_FILESYSTEM],
 
             fi
             if test "x$ax_lib" = "x"; then
-                AC_MSG_ERROR(Could not find a version of the library!)
+                AC_MSG_ERROR(Could not find a version of the Boost::Filesystem library!)
             fi
 			if test "x$link_filesystem" != "xyes"; then
 				AC_MSG_ERROR(Could not link against $ax_lib !)

--- a/m4/ax_boost_iostreams.m4
+++ b/m4/ax_boost_iostreams.m4
@@ -29,7 +29,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 21
+#serial 22
 
 AC_DEFUN([AX_BOOST_IOSTREAMS],
 [
@@ -103,7 +103,7 @@ AC_DEFUN([AX_BOOST_IOSTREAMS],
 
             fi
             if test "x$ax_lib" = "x"; then
-                AC_MSG_ERROR(Could not find a version of the library!)
+                AC_MSG_ERROR(Could not find a version of the Boost::IOStreams library!)
             fi
 			if test "x$link_iostreams" != "xyes"; then
 				AC_MSG_ERROR(Could not link against $ax_lib !)

--- a/m4/ax_boost_locale.m4
+++ b/m4/ax_boost_locale.m4
@@ -29,7 +29,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 2
+#serial 3
 
 AC_DEFUN([AX_BOOST_LOCALE],
 [
@@ -106,7 +106,7 @@ AC_DEFUN([AX_BOOST_LOCALE],
 
             fi
             if test "x$ax_lib" = "x"; then
-                AC_MSG_ERROR(Could not find a version of the library!)
+                AC_MSG_ERROR(Could not find a version of the Boost::Locale library!)
             fi
 			if test "x$link_locale" = "xno"; then
 				AC_MSG_ERROR(Could not link against $ax_lib !)

--- a/m4/ax_boost_log.m4
+++ b/m4/ax_boost_log.m4
@@ -31,7 +31,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 2
+#serial 3
 
 AC_DEFUN([AX_BOOST_LOG],
 [
@@ -108,7 +108,7 @@ AC_DEFUN([AX_BOOST_LOG],
 			fi
 
 			if test "x$ax_lib" = "x"; then
-				AC_MSG_ERROR(Could not find a version of the library!)
+				AC_MSG_ERROR(Could not find a version of the Boost::Log library!)
 			fi
 
 			if test "x$link_log" = "xno"; then

--- a/m4/ax_boost_log_setup.m4
+++ b/m4/ax_boost_log_setup.m4
@@ -31,7 +31,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 2
+#serial 3
 
 AC_DEFUN([AX_BOOST_LOG_SETUP],
 [
@@ -100,7 +100,7 @@ AC_DEFUN([AX_BOOST_LOG_SETUP],
 		fi
 
 		if test "x$ax_lib" = "x"; then
-			AC_MSG_ERROR(Could not find a version of the library!)
+			AC_MSG_ERROR(Could not find a version of the Boost::Log_Setup library!)
 		fi
 
 		if test "x$link_log_setup" = "xno"; then

--- a/m4/ax_boost_program_options.m4
+++ b/m4/ax_boost_program_options.m4
@@ -29,7 +29,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 25
+#serial 26
 
 AC_DEFUN([AX_BOOST_PROGRAM_OPTIONS],
 [
@@ -96,7 +96,7 @@ AC_DEFUN([AX_BOOST_PROGRAM_OPTIONS],
                   done
                 fi
             if test "x$ax_lib" = "x"; then
-                AC_MSG_ERROR(Could not find a version of the library!)
+                AC_MSG_ERROR(Could not find a version of the Boost::Program_Options library!)
             fi
 				if test "x$link_program_options" != "xyes"; then
 					AC_MSG_ERROR([Could not link against [$ax_lib] !])

--- a/m4/ax_boost_serialization.m4
+++ b/m4/ax_boost_serialization.m4
@@ -29,7 +29,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 22
+#serial 23
 
 AC_DEFUN([AX_BOOST_SERIALIZATION],
 [
@@ -104,7 +104,7 @@ AC_DEFUN([AX_BOOST_SERIALIZATION],
 
             fi
             if test "x$ax_lib" = "x"; then
-                AC_MSG_ERROR(Could not find a version of the library!)
+                AC_MSG_ERROR(Could not find a version of the Boost::Serialization library!)
             fi
 			if test "x$link_serialization" != "xyes"; then
 				AC_MSG_ERROR(Could not link against $ax_lib !)

--- a/m4/ax_boost_signals.m4
+++ b/m4/ax_boost_signals.m4
@@ -30,7 +30,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 22
+#serial 23
 
 AC_DEFUN([AX_BOOST_SIGNALS],
 [
@@ -101,7 +101,7 @@ AC_DEFUN([AX_BOOST_SIGNALS],
 
             fi
             if test "x$ax_lib" = "x"; then
-                AC_MSG_ERROR(Could not find a version of the library!)
+                AC_MSG_ERROR(Could not find a version of the Boost::Signals library!)
             fi
 			if test "x$link_signals" != "xyes"; then
 				AC_MSG_ERROR(Could not link against $ax_lib !)

--- a/m4/ax_boost_system.m4
+++ b/m4/ax_boost_system.m4
@@ -31,7 +31,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 19
+#serial 20
 
 AC_DEFUN([AX_BOOST_SYSTEM],
 [
@@ -108,7 +108,7 @@ AC_DEFUN([AX_BOOST_SYSTEM],
 
             fi
             if test "x$ax_lib" = "x"; then
-                AC_MSG_ERROR(Could not find a version of the library!)
+                AC_MSG_ERROR(Could not find a version of the Boost::System library!)
             fi
 			if test "x$link_system" = "xno"; then
 				AC_MSG_ERROR(Could not link against $ax_lib !)

--- a/m4/ax_boost_test_exec_monitor.m4
+++ b/m4/ax_boost_test_exec_monitor.m4
@@ -30,7 +30,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 21
+#serial 22
 
 AC_DEFUN([AX_BOOST_TEST_EXEC_MONITOR],
 [
@@ -126,7 +126,7 @@ AC_DEFUN([AX_BOOST_TEST_EXEC_MONITOR],
                done
             fi
             if test "x$ax_lib" = "x"; then
-                AC_MSG_ERROR(Could not find a version of the library!)
+                AC_MSG_ERROR(Could not find a version of the Boost::Test_Exec_Monitor library!)
             fi
 			if test "x$link_test_exec_monitor" != "xyes"; then
 				AC_MSG_ERROR(Could not link against $ax_lib !)

--- a/m4/ax_boost_thread.m4
+++ b/m4/ax_boost_thread.m4
@@ -30,7 +30,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 31
+#serial 32
 
 AC_DEFUN([AX_BOOST_THREAD],
 [
@@ -130,7 +130,7 @@ AC_DEFUN([AX_BOOST_THREAD],
 
             fi
             if test "x$ax_lib" = "x"; then
-                AC_MSG_ERROR(Could not find a version of the library!)
+                AC_MSG_ERROR(Could not find a version of the Boost::Thread library!)
             fi
             if test "x$link_thread" = "xno"; then
                 AC_MSG_ERROR(Could not link against $ax_lib !)

--- a/m4/ax_boost_unit_test_framework.m4
+++ b/m4/ax_boost_unit_test_framework.m4
@@ -29,7 +29,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 21
+#serial 22
 
 AC_DEFUN([AX_BOOST_UNIT_TEST_FRAMEWORK],
 [
@@ -124,7 +124,7 @@ AC_DEFUN([AX_BOOST_UNIT_TEST_FRAMEWORK],
                done
             fi
             if test "x$ax_lib" = "x"; then
-                AC_MSG_ERROR(Could not find a version of the library!)
+                AC_MSG_ERROR(Could not find a version of the Boost::Unit_Test_Framework library!)
             fi
 			if test "x$link_unit_test_framework" != "xyes"; then
 				AC_MSG_ERROR(Could not link against $ax_lib !)

--- a/m4/ax_boost_wave.m4
+++ b/m4/ax_boost_wave.m4
@@ -30,7 +30,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 16
+#serial 17
 
 AC_DEFUN([AX_BOOST_WAVE],
 [
@@ -104,7 +104,7 @@ AC_DEFUN([AX_BOOST_WAVE],
                done
             fi
             if test "x$ax_lib" = "x"; then
-                AC_MSG_ERROR(Could not find a version of the library!)
+                AC_MSG_ERROR(Could not find a version of the Boost::Wave library!)
             fi
 			if test "x$link_wave" != "xyes"; then
 				AC_MSG_ERROR(Could not link against $ax_lib !)

--- a/m4/ax_boost_wserialization.m4
+++ b/m4/ax_boost_wserialization.m4
@@ -29,7 +29,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 21
+#serial 22
 
 AC_DEFUN([AX_BOOST_WSERIALIZATION],
 [
@@ -103,7 +103,7 @@ AC_DEFUN([AX_BOOST_WSERIALIZATION],
 
             fi
             if test "x$ax_lib" = "x"; then
-                AC_MSG_ERROR(Could not find a version of the library!)
+                AC_MSG_ERROR(Could not find a version of the Boost::WSerialization library!)
             fi
 			if test "x$link_wserialization" != "xyes"; then
 				AC_MSG_ERROR(Could not link against $ax_lib !)


### PR DESCRIPTION
When testing for Boost libraries, return the library that could not be found. 

Currently the [Boost::Regex](https://github.com/autoconf-archive/autoconf-archive/blob/master/m4/ax_boost_regex.m4) m4 is the only macro that mentions the library name when it fails.