### PR TITLE
AX_BOOST_BASE: fix Boost detection on some platforms

### DIFF
--- a/m4/ax_boost_base.m4
+++ b/m4/ax_boost_base.m4
@@ -33,7 +33,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 48
+#serial 49
 
 # example boost program (need to pass version)
 m4_define([_AX_BOOST_BASE_PROGRAM],
@@ -133,7 +133,7 @@ AC_DEFUN([_AX_BOOST_BASE_RUNDETECT],[
     libsubdirs="lib/`$CXX -dumpmachine 2>/dev/null` $libsubdirs"
 
     dnl first we check the system location for boost libraries
-    dnl this location ist chosen if boost libraries are installed with the --layout=system option
+    dnl this location is chosen if boost libraries are installed with the --layout=system option
     dnl or if you install boost with RPM
     AS_IF([test "x$_AX_BOOST_BASE_boost_path" != "x"],[
         AC_MSG_CHECKING([for boostlib >= $1 ($WANT_BOOST_VERSION) includes in "$_AX_BOOST_BASE_boost_path/include"])

--- a/m4/ax_boost_base.m4
+++ b/m4/ax_boost_base.m4
@@ -33,7 +33,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 47
+#serial 48
 
 # example boost program (need to pass version)
 m4_define([_AX_BOOST_BASE_PROGRAM],
@@ -125,6 +125,12 @@ AC_DEFUN([_AX_BOOST_BASE_RUNDETECT],[
       [i?86],[multiarch_libsubdir="lib/i386-${host_os}"],
       [multiarch_libsubdir="lib/${host_cpu}-${host_os}"]
     )
+
+    dnl some arches may advertise a cpu type that doesn't line up with their
+    dnl prefix's cpu type. For example, uname may report armv7l while libs are
+    dnl installed to /usr/lib/arm-linux-gnueabihf. Try getting the compiler's
+    dnl value for an extra chance of finding the correct path.
+    libsubdirs="lib/`$CXX -dumpmachine 2>/dev/null` $libsubdirs"
 
     dnl first we check the system location for boost libraries
     dnl this location ist chosen if boost libraries are installed with the --layout=system option


### PR DESCRIPTION
When the libpath doesn't line up with the value from config.sub, we don't find
the correct path to boost's libs. For example, uname may report `armv7l` while 
libs are installed to `/usr/lib/arm-linux-gnueabihf`. This trys another path 
before giving up.

We've been using [this patch](https://github.com/bitcoin/bitcoin/commit/54c7df81f3e5f81cb91646acaf82074a3a6be3b2) in our repo for some time, but accidentally lost it when we [last updated the `boost_base.m4`](https://github.com/bitcoin/bitcoin/pull/15461), resulting in Boost being reported as [unavailable on some systems](https://github.com/bitcoin/bitcoin/issues/17010).