### PR TITLE
ax_pthread.m4: avoid unused-but-set-parameter warning

### DIFF
--- a/m4/ax_pthread.m4
+++ b/m4/ax_pthread.m4
@@ -82,7 +82,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 25
+#serial 26
 
 AU_ALIAS([ACX_PTHREAD], [AX_PTHREAD])
 AC_DEFUN([AX_PTHREAD], [
@@ -371,7 +371,13 @@ for ax_pthread_try_flag in $ax_pthread_flags; do
 #                       if $ax_pthread_check_cond
 #                        error "$ax_pthread_check_macro must be defined"
 #                       endif
-                        static void routine(void *a) { a = 0; }
+                        static void *some_global = NULL;
+                        static void routine(void *a)
+                          {
+                             /* To avoid any unused-parameter or
+                                unused-but-set-parameter warning.  */
+                             some_global = a;
+                          }
                         static void *start_routine(void *a) { return a; }],
                        [pthread_t th; pthread_attr_t attr;
                         pthread_create(&th, 0, start_routine, 0);


### PR DESCRIPTION
With gcc's warning -Wunused-but-set-parameter enabled (which is enabled
with -Wextra) and -Werror, configuring with the AX_PTHREAD macro fails
with:

    configure:6783: checking whether pthreads work with -pthread
    configure:6877: ccache gcc -o conftest -g3 -O0 -Werror -Wall -Wextra  -fmax-errors=1 -fdiagnostics-color=always -Wall -DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_22 -pthread   conftest.c   >&5
    conftest.c: In function 'routine':
    conftest.c:37:51: error: parameter 'a' set but not used [-Werror=unused-but-set-parameter]
                             static void routine(void *a) { a = 0; }
                                                       ^
    cc1: all warnings being treated as errors

Change the code to make it use, not only set, the parameter.