### PR TITLE
fix AX_ADD_FORTIFY_SOURCE for msys2

### DIFF
--- a/m4/ax_add_fortify_source.m4
+++ b/m4/ax_add_fortify_source.m4
@@ -9,9 +9,9 @@
 # DESCRIPTION
 #
 #   Check whether -D_FORTIFY_SOURCE=2 can be added to CPPFLAGS without macro
-#   redefinition warnings. Some distributions (such as Gentoo Linux) enable
-#   _FORTIFY_SOURCE globally in their compilers, leading to unnecessary
-#   warnings in the form of
+#   redefinition warnings or linker errors. Some distributions (such as
+#   Gentoo Linux) enable _FORTIFY_SOURCE globally in their compilers,
+#   leading to unnecessary warnings in the form of
 #
 #     <command-line>:0:0: error: "_FORTIFY_SOURCE" redefined [-Werror]
 #     <built-in>: note: this is the location of the previous definition
@@ -20,34 +20,55 @@
 #   _FORTIFY_SOURCE is already defined, and if not, adds -D_FORTIFY_SOURCE=2
 #   to CPPFLAGS.
 #
+#   Newer msys2 comes with a bug in headers-git-7.0.0.5546.d200317d-1. It
+#   dropped -D_FORTIFY_SOURCE=2 support, and would need -lssp or
+#   -fstack-protector.  See
+#   https://github.com/msys2/MINGW-packages/issues/5803. Try to actually
+#   link it.
+#
 # LICENSE
 #
 #   Copyright (c) 2017 David Seifert <soap@gentoo.org>
+#   Copyright (c) 2019 Reini Urban <rurban@cpan.org>
 #
 #   Copying and distribution of this file, with or without modification, are
 #   permitted in any medium without royalty provided the copyright notice
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 2
+#serial 3
 
 AC_DEFUN([AX_ADD_FORTIFY_SOURCE],[
     AC_MSG_CHECKING([whether to add -D_FORTIFY_SOURCE=2 to CPPFLAGS])
     AC_LINK_IFELSE([
-        AC_LANG_SOURCE(
+        AC_LANG_PROGRAM([],
             [[
-                int main() {
                 #ifndef _FORTIFY_SOURCE
                     return 0;
                 #else
                     this_is_an_error;
                 #endif
-                }
             ]]
-        )], [
-            AC_MSG_RESULT([yes])
-            CPPFLAGS="$CPPFLAGS -D_FORTIFY_SOURCE=2"
-        ], [
+        )],
+        AC_LINK_IFELSE([
+            AC_LANG_SOURCE([[
+                #define _FORTIFY_SOURCE 2
+                #include <string.h>
+                int main() {
+                    const char *s = "  ";
+                    strcpy(s, "ok");
+                    return 0;
+                }
+              ]]
+            )],
+            [
+              AC_MSG_RESULT([yes])
+              CPPFLAGS="$CPPFLAGS -D_FORTIFY_SOURCE=2"
+            ], [
+              AC_MSG_RESULT([no])
+            ],
+        ),
+        [
             AC_MSG_RESULT([no])
     ])
 ])


### PR DESCRIPTION
msys2 just dropped _FORTIFY_SOURCE support.
See https://github.com/msys2/MINGW-packages/issues/5803
Try to actually link it.