### PR TITLE
add AX_GCC_FUNC_ATTRIBUTE(gnu_format)

### DIFF
--- a/m4/ax_gcc_func_attribute.m4
+++ b/m4/ax_gcc_func_attribute.m4
@@ -42,6 +42,7 @@
 #    flatten
 #    format
 #    format_arg
+#    gnu_format
 #    gnu_inline
 #    hot
 #    ifunc
@@ -77,7 +78,7 @@
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 9
+#serial 10
 
 AC_DEFUN([AX_GCC_FUNC_ATTRIBUTE], [
     AS_VAR_PUSHDEF([ac_var], [ax_cv_have_func_attribute_$1])
@@ -139,6 +140,9 @@ AC_DEFUN([AX_GCC_FUNC_ATTRIBUTE], [
                 ],
                 [format], [
                     int foo(const char *p, ...) __attribute__(($1(printf, 1, 2)));
+                ],
+                [gnu_format], [
+                    int foo(const char *p, ...) __attribute__((format(gnu_printf, 1, 2)));
                 ],
                 [format_arg], [
                     char *foo(const char *p) __attribute__(($1(1)));


### PR DESCRIPTION
newer gcc warns about function might be a candidate for
gnu_printf format attribute [-Wsuggest-attribute=format]

Usage: AX_GCC_FUNC_ATTRIBUTE(gnu_format)
and:
  #ifdef HAVE_FUNC_ATTRIBUTE_GNUFORMAT
    \__attribute__ ((format (gnu_printf, 1, 2)))
  #elif HAVE_FUNC_ATTRIBUTE_FORMAT
    \__attribute__ ((format (printf, 1, 2)))
  #endif