### PR TITLE
ax_have_epoll: avoid -Wunused-but-set-variable errors

### DIFF
--- a/m4/ax_have_epoll.m4
+++ b/m4/ax_have_epoll.m4
@@ -42,7 +42,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 11
+#serial 12
 
 AC_DEFUN([AX_HAVE_EPOLL], [dnl
   ax_have_epoll_cppflags="${CPPFLAGS}"
@@ -59,10 +59,10 @@ AC_DEFUN([AX_HAVE_EPOLL], [dnl
 #  endif
 #endif
 ], [dnl
-int fd, rc;
+int fd;
 struct epoll_event ev;
 fd = epoll_create(128);
-rc = epoll_wait(fd, &ev, 1, 0);])],
+epoll_wait(fd, &ev, 1, 0);])],
       [ax_cv_have_epoll=yes],
       [ax_cv_have_epoll=no])])
   CPPFLAGS="${ax_have_epoll_cppflags}"
@@ -89,11 +89,11 @@ AC_DEFUN([AX_HAVE_EPOLL_PWAIT], [dnl
 #include <sys/epoll.h>
 #include <signal.h>
 ], [dnl
-int fd, rc;
+int fd;
 struct epoll_event ev;
 fd = epoll_create(128);
-rc = epoll_wait(fd, &ev, 1, 0);
-rc = epoll_pwait(fd, &ev, 1, 0, (sigset_t const *)(0));])],
+epoll_wait(fd, &ev, 1, 0);
+epoll_pwait(fd, &ev, 1, 0, (sigset_t const *)(0));])],
       [ax_cv_have_epoll_pwait=yes],
       [ax_cv_have_epoll_pwait=no])])
   CPPFLAGS="${ax_have_epoll_cppflags}"


### PR DESCRIPTION
When building with -Werror -Wunused-but-set-variable, the code snippets
in this file generate a warning, causing the test to spuriously fail.
Remove the "rc" variables, since they're not used.

Sample config.log output:

    configure:22489: checking for Linux epoll(7) interface
    configure:22515: ccache gcc -o conftest -g3 -O0 -Wall -Werror -Wextra -Wno-type-limits -Wno-missing-declarations -Wno-missing-field-initializers -Wno-si      gn-compare -Wno-implicit-fallthrough -Wno-unused-parameter -I/home/smarchi/install/include -DHAVE_LINUX_VERSION_H -L/home/smarchi/install/lib conftest.c       -lurcu-cds  >&5
    conftest.c: In function 'main':
    conftest.c:184:9: error: variable 'rc' set but not used [-Werror=unused-but-set-variable]
     int fd, rc;
             ^~
    cc1: all warnings being treated as errors