### PR TITLE
Don't check the __cplusplus version on xlC

### DIFF
--- a/m4/ax_cxx_compile_stdcxx.m4
+++ b/m4/ax_cxx_compile_stdcxx.m4
@@ -165,7 +165,8 @@ m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_11], [[
 
 #error "This is not a C++ compiler"
 
-#elif __cplusplus < 201103L
+// xlC always defines __cplusplus as 199711L, even when using a later version.
+#elif __cplusplus < 201103L && !defined(__xlC__)
 
 #error "This is not a C++11 compiler"
 
@@ -456,7 +457,8 @@ m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_14], [[
 
 #error "This is not a C++ compiler"
 
-#elif __cplusplus < 201402L
+// xlC always defines __cplusplus as 199711L, even when using a later version.
+#elif __cplusplus < 201402L && !defined(__xlC__)
 
 #error "This is not a C++14 compiler"
 
@@ -580,7 +582,8 @@ m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_17], [[
 
 #error "This is not a C++ compiler"
 
-#elif __cplusplus < 201703L
+// xlC always defines __cplusplus as 199711L, even when using a later version.
+#elif __cplusplus < 201703L && !defined(__xlC__)
 
 #error "This is not a C++17 compiler"
 


### PR DESCRIPTION
It always defines it as 199711L. See:
https://www.ibm.com/support/knowledgecenter/en/SSLTBW_2.3.0/com.ibm.zos.v2r3.cbclx01/cplr367.htm
(contrast with the documentation for __STDC_VERSION__)

Test output with xlC 16.1.0:
bash-4.4$ /opt/IBM/xlC/16.1.0/bin/xlC test.cc
bash-4.4$ ./a.out
version 199711
bash-4.4$ /opt/IBM/xlC/16.1.0/bin/xlC test.cc -qlanglvl=extended0x
bash-4.4$ ./a.out
version 199711
bash-4.4$ cat test.cc
int main() {
  fprintf(stderr, "version %li\n", __cplusplus);
}