### PR TITLE
ax_prog_cc_for_build.m4: bug fixes

### DIFF
--- a/m4/ax_prog_cc_for_build.m4
+++ b/m4/ax_prog_cc_for_build.m4
@@ -57,7 +57,9 @@ pushdef([CPP], CPP_FOR_BUILD)dnl
 pushdef([GCC], GCC_FOR_BUILD)dnl
 pushdef([CFLAGS], CFLAGS_FOR_BUILD)dnl
 pushdef([CPPFLAGS], CPPFLAGS_FOR_BUILD)dnl
+pushdef([EXEEXT], BUILD_EXEEXT)dnl
 pushdef([LDFLAGS], LDFLAGS_FOR_BUILD)dnl
+pushdef([OBJEXT], BUILD_OBJEXT)dnl
 pushdef([host], build)dnl
 pushdef([host_alias], build_alias)dnl
 pushdef([host_cpu], build_cpu)dnl
@@ -92,6 +94,8 @@ AS_IF([test -n "$build"],      [ac_build_tool_prefix="$build-"],
       [test -n "$build_alias"],[ac_build_tool_prefix="$build_alias-"])
 
 AC_PROG_CC
+_AC_COMPILER_EXEEXT
+_AC_COMPILER_OBJEXT
 AC_PROG_CPP
 
 dnl Restore the old definitions
@@ -120,7 +124,9 @@ popdef([host_vendor])dnl
 popdef([host_cpu])dnl
 popdef([host_alias])dnl
 popdef([host])dnl
+popdef([OBJEXT])dnl
 popdef([LDFLAGS])dnl
+popdef([EXEEXT])dnl
 popdef([CPPFLAGS])dnl
 popdef([CFLAGS])dnl
 popdef([GCC])dnl
@@ -140,8 +146,6 @@ popdef([ac_cv_prog_CPP])dnl
 
 dnl Finally, set Makefile variables
 dnl
-BUILD_EXEEXT=$ac_build_exeext
-BUILD_OBJEXT=$ac_build_objext
 AC_SUBST(BUILD_EXEEXT)dnl
 AC_SUBST(BUILD_OBJEXT)dnl
 AC_SUBST([CFLAGS_FOR_BUILD])dnl

--- a/m4/ax_prog_cc_for_build.m4
+++ b/m4/ax_prog_cc_for_build.m4
@@ -75,24 +75,13 @@ pushdef([am_cv_CC_dependencies_compiler_type], am_cv_build_CC_dependencies_compi
 pushdef([am_cv_prog_cc_c_o], am_cv_build_prog_cc_c_o)dnl
 pushdef([cross_compiling], cross_compiling_build)dnl
 
-dnl auto(re)conf 2.69:
-dnl The following variables are used as global variables by, e.g.,
-dnl the functions `ac_fn_c_try_compile' and `ac_fn_c_try_cpp', and
-dnl are created by configure when needed.  Thus, pushing them will
-dnl not work.  Thus we store them in `save' variables and restore
-dnl them at the end.
-dnl
-_save_ax_prog_cc_for_build__ac_ext="$ac_ext"
-_save_ax_prog_cc_for_build__ac_cpp="$ac_cpp"
-_save_ax_prog_cc_for_build__ac_compile="$ac_compile"
-_save_ax_prog_cc_for_build__ac_link="$ac_link"
-
 cross_compiling_build=no
 
 ac_build_tool_prefix=
 AS_IF([test -n "$build"],      [ac_build_tool_prefix="$build-"],
       [test -n "$build_alias"],[ac_build_tool_prefix="$build_alias-"])
 
+AC_LANG_PUSH([C])
 AC_PROG_CC
 _AC_COMPILER_EXEEXT
 _AC_COMPILER_OBJEXT
@@ -100,16 +89,6 @@ AC_PROG_CPP
 
 dnl Restore the old definitions
 dnl
-ac_ext="$_save_ax_prog_cc_for_build__ac_ext"
-ac_cpp="$_save_ax_prog_cc_for_build__ac_cpp"
-ac_compile="$_save_ax_prog_cc_for_build__ac_compile"
-ac_link="$_save_ax_prog_cc_for_build__ac_link"
-ac_compiler_gnu=$ac_cv_c_compiler_gnu
-_save_ax_prog_cc_for_build__ac_ext=""
-_save_ax_prog_cc_for_build__ac_cpp=""
-_save_ax_prog_cc_for_build__ac_compile=""
-_save_ax_prog_cc_for_build__ac_link=""
-
 popdef([cross_compiling])dnl
 popdef([am_cv_prog_cc_c_o])dnl
 popdef([am_cv_CC_dependencies_compiler_type])dnl
@@ -143,6 +122,11 @@ popdef([ac_cv_prog_cc_works])dnl
 popdef([ac_cv_prog_cc_c89])dnl
 popdef([ac_cv_prog_gcc])dnl
 popdef([ac_cv_prog_CPP])dnl
+
+dnl restore global variables ac_ext, ac_cpp, ac_compile,
+dnl ac_link, ac_compiler_gnu (dependant on the current
+dnl language after popping):
+AC_LANG_POP([C])
 
 dnl Finally, set Makefile variables
 dnl

--- a/m4/ax_prog_cc_for_build.m4
+++ b/m4/ax_prog_cc_for_build.m4
@@ -32,7 +32,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 9
+#serial 18
 
 AU_ALIAS([AC_PROG_CC_FOR_BUILD], [AX_PROG_CC_FOR_BUILD])
 AC_DEFUN([AX_PROG_CC_FOR_BUILD], [dnl

--- a/m4/ax_prog_cc_for_build.m4
+++ b/m4/ax_prog_cc_for_build.m4
@@ -53,6 +53,7 @@ pushdef([ac_exeext], ac_build_exeext)dnl
 pushdef([ac_objext], ac_build_objext)dnl
 pushdef([CC], CC_FOR_BUILD)dnl
 pushdef([CPP], CPP_FOR_BUILD)dnl
+pushdef([GCC], GCC_FOR_BUILD)dnl
 pushdef([CFLAGS], CFLAGS_FOR_BUILD)dnl
 pushdef([CPPFLAGS], CPPFLAGS_FOR_BUILD)dnl
 pushdef([LDFLAGS], LDFLAGS_FOR_BUILD)dnl
@@ -99,6 +100,7 @@ popdef([host])dnl
 popdef([LDFLAGS])dnl
 popdef([CPPFLAGS])dnl
 popdef([CFLAGS])dnl
+popdef([GCC])dnl
 popdef([CPP])dnl
 popdef([CC])dnl
 popdef([ac_objext])dnl

--- a/m4/ax_prog_cc_for_build.m4
+++ b/m4/ax_prog_cc_for_build.m4
@@ -38,7 +38,6 @@ AU_ALIAS([AC_PROG_CC_FOR_BUILD], [AX_PROG_CC_FOR_BUILD])
 AC_DEFUN([AX_PROG_CC_FOR_BUILD], [dnl
 AC_REQUIRE([AC_PROG_CC])dnl
 AC_REQUIRE([AC_PROG_CPP])dnl
-AC_REQUIRE([AC_EXEEXT])dnl
 AC_REQUIRE([AC_CANONICAL_HOST])dnl
 
 dnl Use the standard macros, but make them use other variable names
@@ -78,7 +77,6 @@ ac_tool_prefix=
 
 AC_PROG_CC
 AC_PROG_CPP
-AC_EXEEXT
 
 ac_tool_prefix=$save_ac_tool_prefix
 cross_compiling=$save_cross_compiling

--- a/m4/ax_prog_cc_for_build.m4
+++ b/m4/ax_prog_cc_for_build.m4
@@ -67,19 +67,21 @@ pushdef([ac_cv_host_alias], ac_cv_build_alias)dnl
 pushdef([ac_cv_host_cpu], ac_cv_build_cpu)dnl
 pushdef([ac_cv_host_vendor], ac_cv_build_vendor)dnl
 pushdef([ac_cv_host_os], ac_cv_build_os)dnl
+pushdef([ac_tool_prefix], ac_build_tool_prefix)dnl
 pushdef([ac_cpp], ac_build_cpp)dnl
 pushdef([ac_compile], ac_build_compile)dnl
 pushdef([ac_link], ac_build_link)dnl
 
 save_cross_compiling=$cross_compiling
-save_ac_tool_prefix=$ac_tool_prefix
 cross_compiling=no
-ac_tool_prefix=
+
+ac_build_tool_prefix=
+AS_IF([test -n "$build"],      [ac_build_tool_prefix="$build-"],
+      [test -n "$build_alias"],[ac_build_tool_prefix="$build_alias-"])
 
 AC_PROG_CC
 AC_PROG_CPP
 
-ac_tool_prefix=$save_ac_tool_prefix
 cross_compiling=$save_cross_compiling
 
 dnl Restore the old definitions
@@ -87,6 +89,7 @@ dnl
 popdef([ac_link])dnl
 popdef([ac_compile])dnl
 popdef([ac_cpp])dnl
+popdef([ac_tool_prefix])dnl
 popdef([ac_cv_host_os])dnl
 popdef([ac_cv_host_vendor])dnl
 popdef([ac_cv_host_cpu])dnl

--- a/m4/ax_prog_cc_for_build.m4
+++ b/m4/ax_prog_cc_for_build.m4
@@ -38,6 +38,7 @@ AU_ALIAS([AC_PROG_CC_FOR_BUILD], [AX_PROG_CC_FOR_BUILD])
 AC_DEFUN([AX_PROG_CC_FOR_BUILD], [dnl
 AC_REQUIRE([AC_PROG_CC])dnl
 AC_REQUIRE([AC_PROG_CPP])dnl
+AC_REQUIRE([AC_CANONICAL_BUILD])dnl
 
 dnl Use the standard macros, but make them use other variable names
 dnl

--- a/m4/ax_prog_cc_for_build.m4
+++ b/m4/ax_prog_cc_for_build.m4
@@ -38,7 +38,6 @@ AU_ALIAS([AC_PROG_CC_FOR_BUILD], [AX_PROG_CC_FOR_BUILD])
 AC_DEFUN([AX_PROG_CC_FOR_BUILD], [dnl
 AC_REQUIRE([AC_PROG_CC])dnl
 AC_REQUIRE([AC_PROG_CPP])dnl
-AC_REQUIRE([AC_CANONICAL_HOST])dnl
 
 dnl Use the standard macros, but make them use other variable names
 dnl
@@ -47,6 +46,7 @@ pushdef([ac_cv_prog_gcc], ac_cv_build_prog_gcc)dnl
 pushdef([ac_cv_prog_cc_works], ac_cv_build_prog_cc_works)dnl
 pushdef([ac_cv_prog_cc_cross], ac_cv_build_prog_cc_cross)dnl
 pushdef([ac_cv_prog_cc_g], ac_cv_build_prog_cc_g)dnl
+pushdef([ac_cv_c_compiler_gnu], ac_cv_build_c_compiler_gnu)dnl
 pushdef([ac_cv_exeext], ac_cv_build_exeext)dnl
 pushdef([ac_cv_objext], ac_cv_build_objext)dnl
 pushdef([ac_exeext], ac_build_exeext)dnl
@@ -68,12 +68,21 @@ pushdef([ac_cv_host_cpu], ac_cv_build_cpu)dnl
 pushdef([ac_cv_host_vendor], ac_cv_build_vendor)dnl
 pushdef([ac_cv_host_os], ac_cv_build_os)dnl
 pushdef([ac_tool_prefix], ac_build_tool_prefix)dnl
-pushdef([ac_cpp], ac_build_cpp)dnl
-pushdef([ac_compile], ac_build_compile)dnl
-pushdef([ac_link], ac_build_link)dnl
+pushdef([cross_compiling], cross_compiling_build)dnl
 
-save_cross_compiling=$cross_compiling
-cross_compiling=no
+dnl auto(re)conf 2.69:
+dnl The following variables are used as global variables by, e.g.,
+dnl the functions `ac_fn_c_try_compile' and `ac_fn_c_try_cpp', and
+dnl are created by configure when needed.  Thus, pushing them will
+dnl not work.  Thus we store them in `save' variables and restore
+dnl them at the end.
+dnl
+_save_ax_prog_cc_for_build__ac_ext="$ac_ext"
+_save_ax_prog_cc_for_build__ac_cpp="$ac_cpp"
+_save_ax_prog_cc_for_build__ac_compile="$ac_compile"
+_save_ax_prog_cc_for_build__ac_link="$ac_link"
+
+cross_compiling_build=no
 
 ac_build_tool_prefix=
 AS_IF([test -n "$build"],      [ac_build_tool_prefix="$build-"],
@@ -82,13 +91,19 @@ AS_IF([test -n "$build"],      [ac_build_tool_prefix="$build-"],
 AC_PROG_CC
 AC_PROG_CPP
 
-cross_compiling=$save_cross_compiling
-
 dnl Restore the old definitions
 dnl
-popdef([ac_link])dnl
-popdef([ac_compile])dnl
-popdef([ac_cpp])dnl
+ac_ext="$_save_ax_prog_cc_for_build__ac_ext"
+ac_cpp="$_save_ax_prog_cc_for_build__ac_cpp"
+ac_compile="$_save_ax_prog_cc_for_build__ac_compile"
+ac_link="$_save_ax_prog_cc_for_build__ac_link"
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+_save_ax_prog_cc_for_build__ac_ext=""
+_save_ax_prog_cc_for_build__ac_cpp=""
+_save_ax_prog_cc_for_build__ac_compile=""
+_save_ax_prog_cc_for_build__ac_link=""
+
+popdef([cross_compiling])dnl
 popdef([ac_tool_prefix])dnl
 popdef([ac_cv_host_os])dnl
 popdef([ac_cv_host_vendor])dnl
@@ -110,6 +125,7 @@ popdef([ac_objext])dnl
 popdef([ac_exeext])dnl
 popdef([ac_cv_objext])dnl
 popdef([ac_cv_exeext])dnl
+popdef([ac_cv_c_compiler_gnu])dnl
 popdef([ac_cv_prog_cc_g])dnl
 popdef([ac_cv_prog_cc_cross])dnl
 popdef([ac_cv_prog_cc_works])dnl

--- a/m4/ax_prog_cc_for_build.m4
+++ b/m4/ax_prog_cc_for_build.m4
@@ -42,6 +42,7 @@ AC_REQUIRE([AC_PROG_CPP])dnl
 dnl Use the standard macros, but make them use other variable names
 dnl
 pushdef([ac_cv_prog_CPP], ac_cv_build_prog_CPP)dnl
+pushdef([ac_cv_prog_cc_c89], ac_cv_build_prog_cc_c89)dnl
 pushdef([ac_cv_prog_gcc], ac_cv_build_prog_gcc)dnl
 pushdef([ac_cv_prog_cc_works], ac_cv_build_prog_cc_works)dnl
 pushdef([ac_cv_prog_cc_cross], ac_cv_build_prog_cc_cross)dnl
@@ -68,6 +69,8 @@ pushdef([ac_cv_host_cpu], ac_cv_build_cpu)dnl
 pushdef([ac_cv_host_vendor], ac_cv_build_vendor)dnl
 pushdef([ac_cv_host_os], ac_cv_build_os)dnl
 pushdef([ac_tool_prefix], ac_build_tool_prefix)dnl
+pushdef([am_cv_CC_dependencies_compiler_type], am_cv_build_CC_dependencies_compiler_type)dnl
+pushdef([am_cv_prog_cc_c_o], am_cv_build_prog_cc_c_o)dnl
 pushdef([cross_compiling], cross_compiling_build)dnl
 
 dnl auto(re)conf 2.69:
@@ -104,6 +107,8 @@ _save_ax_prog_cc_for_build__ac_compile=""
 _save_ax_prog_cc_for_build__ac_link=""
 
 popdef([cross_compiling])dnl
+popdef([am_cv_prog_cc_c_o])dnl
+popdef([am_cv_CC_dependencies_compiler_type])dnl
 popdef([ac_tool_prefix])dnl
 popdef([ac_cv_host_os])dnl
 popdef([ac_cv_host_vendor])dnl
@@ -129,6 +134,7 @@ popdef([ac_cv_c_compiler_gnu])dnl
 popdef([ac_cv_prog_cc_g])dnl
 popdef([ac_cv_prog_cc_cross])dnl
 popdef([ac_cv_prog_cc_works])dnl
+popdef([ac_cv_prog_cc_c89])dnl
 popdef([ac_cv_prog_gcc])dnl
 popdef([ac_cv_prog_CPP])dnl
 


### PR DESCRIPTION
This series of commits fixes bugs of `AX_PROG_CC_FOR_BUILD`.  Here simple test files:

`bootstrap.sh`:
~~~sh
#! /usr/bin/sh
# edit dir to test m4 files
m4_localdir=../../m4

mkdir -p build-aux
echo "ACLOCAL_FLAGS = -I $m4_localdir" > Makefile.am
autoreconf -vfi .
~~~
`configure.ac`:
~~~m4
AC_INIT(cc_for_build,0,myemail@org.com)
AC_CONFIG_AUX_DIR([build-aux])
AM_INIT_AUTOMAKE([foreign])
AC_CONFIG_FILES([Makefile])
AX_PROG_CC_FOR_BUILD
AC_OUTPUT

echo "
CC                               $CC
CC_FOR_BUILD            $CC_FOR_BUILD
CFLAGS_FOR_BUILD    $CFLAGS_FOR_BUILD
CPPFLAGS_FOR_BUILD  $CPPFLAGS_FOR_BUILD
LDFLAGS_FOR_BUILD   $LDFLAGS_FOR_BUILD
BUILD_EXEEXT              $BUILD_EXEEXT
BUILD_OBJEXT             $BUILD_OBJEXT
"
~~~

Additionally, happy to do the following if you devs consider it appropriate:
* add `AC_ARG_VAR` for `CC_FOR_BUILD` etc. (incl. documentation)
* apply similar changes to `ax_prog_cxx_for_build.m4` 

Just let me know.