### PR TITLE
ax_add_fortify_source.m4: improve for -Wcpp

### DIFF
--- a/m4/ax_add_fortify_source.m4
+++ b/m4/ax_add_fortify_source.m4
@@ -9,9 +9,9 @@
 # DESCRIPTION
 #
 #   Check whether -D_FORTIFY_SOURCE=2 can be added to CPPFLAGS without macro
-#   redefinition warnings or linker errors. Some distributions (such as
-#   Gentoo Linux) enable _FORTIFY_SOURCE globally in their compilers,
-#   leading to unnecessary warnings in the form of
+#   redefinition warnings, other cpp warnings or linker. Some distributions
+#   (such as Gentoo Linux) enable _FORTIFY_SOURCE globally in their
+#   compilers, leading to unnecessary warnings in the form of
 #
 #     <command-line>:0:0: error: "_FORTIFY_SOURCE" redefined [-Werror]
 #     <built-in>: note: this is the location of the previous definition
@@ -21,10 +21,10 @@
 #   to CPPFLAGS.
 #
 #   Newer mingw-w64 msys2 package comes with a bug in
-#   headers-git-7.0.0.5546.d200317d-1. It broke -D_FORTIFY_SOURCE
-#   support, and would need -lssp or -fstack-protector.  See
-#   https://github.com/msys2/MINGW-packages/issues/5803. Try to
-#   actually link it.
+#   headers-git-7.0.0.5546.d200317d-1. It broke -D_FORTIFY_SOURCE support,
+#   and would need -lssp or -fstack-protector.  See
+#   https://github.com/msys2/MINGW-packages/issues/5803. Try to actually
+#   link it.
 #
 # LICENSE
 #
@@ -36,9 +36,12 @@
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 3
+#serial 4
 
 AC_DEFUN([AX_ADD_FORTIFY_SOURCE],[
+    ac_save_cflags=$CFLAGS
+    ac_cwerror_flag=yes
+    AX_CHECK_COMPILE_FLAG([-Werror],[CFLAGS="$CFLAGS -Werror"])
     AC_MSG_CHECKING([whether to add -D_FORTIFY_SOURCE=2 to CPPFLAGS])
     AC_LINK_IFELSE([
         AC_LANG_PROGRAM([],
@@ -63,12 +66,15 @@ AC_DEFUN([AX_ADD_FORTIFY_SOURCE],[
             )],
             [
               AC_MSG_RESULT([yes])
+              CFLAGS=$ac_save_cflags
               CPPFLAGS="$CPPFLAGS -D_FORTIFY_SOURCE=2"
             ], [
               AC_MSG_RESULT([no])
+              CFLAGS=$ac_save_cflags
             ],
         ),
         [
-            AC_MSG_RESULT([no])
-    ])
+          AC_MSG_RESULT([no])
+          CFLAGS=$ac_save_cflags
+        ])
 ])

--- a/m4/ax_add_fortify_source.m4
+++ b/m4/ax_add_fortify_source.m4
@@ -9,9 +9,9 @@
 # DESCRIPTION
 #
 #   Check whether -D_FORTIFY_SOURCE=2 can be added to CPPFLAGS without macro
-#   redefinition warnings. Some distributions (such as Gentoo Linux) enable
-#   _FORTIFY_SOURCE globally in their compilers, leading to unnecessary
-#   warnings in the form of
+#   redefinition warnings or linker errors. Some distributions (such as
+#   Gentoo Linux) enable _FORTIFY_SOURCE globally in their compilers,
+#   leading to unnecessary warnings in the form of
 #
 #     <command-line>:0:0: error: "_FORTIFY_SOURCE" redefined [-Werror]
 #     <built-in>: note: this is the location of the previous definition
@@ -20,34 +20,55 @@
 #   _FORTIFY_SOURCE is already defined, and if not, adds -D_FORTIFY_SOURCE=2
 #   to CPPFLAGS.
 #
+#   Newer mingw-w64 msys2 package comes with a bug in
+#   headers-git-7.0.0.5546.d200317d-1. It broke -D_FORTIFY_SOURCE
+#   support, and would need -lssp or -fstack-protector.  See
+#   https://github.com/msys2/MINGW-packages/issues/5803. Try to
+#   actually link it.
+#
 # LICENSE
 #
 #   Copyright (c) 2017 David Seifert <soap@gentoo.org>
+#   Copyright (c) 2019 Reini Urban <rurban@cpan.org>
 #
 #   Copying and distribution of this file, with or without modification, are
 #   permitted in any medium without royalty provided the copyright notice
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 2
+#serial 3
 
 AC_DEFUN([AX_ADD_FORTIFY_SOURCE],[
     AC_MSG_CHECKING([whether to add -D_FORTIFY_SOURCE=2 to CPPFLAGS])
     AC_LINK_IFELSE([
-        AC_LANG_SOURCE(
+        AC_LANG_PROGRAM([],
             [[
-                int main() {
                 #ifndef _FORTIFY_SOURCE
                     return 0;
                 #else
                     this_is_an_error;
                 #endif
-                }
             ]]
-        )], [
-            AC_MSG_RESULT([yes])
-            CPPFLAGS="$CPPFLAGS -D_FORTIFY_SOURCE=2"
-        ], [
+        )],
+        AC_LINK_IFELSE([
+            AC_LANG_SOURCE([[
+                #define _FORTIFY_SOURCE 2
+                #include <string.h>
+                int main() {
+                    char *s = " ";
+                    strcpy(s, "x");
+                    return strlen(s)-1;
+                }
+              ]]
+            )],
+            [
+              AC_MSG_RESULT([yes])
+              CPPFLAGS="$CPPFLAGS -D_FORTIFY_SOURCE=2"
+            ], [
+              AC_MSG_RESULT([no])
+            ],
+        ),
+        [
             AC_MSG_RESULT([no])
     ])
 ])


### PR DESCRIPTION
gcc-9 warns when -O is not enabled.
Add linker step for broken msys2 packages.