### PR TITLE
ax_boost_thread: do not set -pthread on Android

### DIFF
--- a/m4/ax_boost_thread.m4
+++ b/m4/ax_boost_thread.m4
@@ -30,7 +30,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 32
+#serial 33
 
 AC_DEFUN([AX_BOOST_THREAD],
 [
@@ -67,13 +67,24 @@ AC_DEFUN([AX_BOOST_THREAD],
         [AC_LANG_PUSH([C++])
              CXXFLAGS_SAVE=$CXXFLAGS
 
-             if test "x$host_os" = "xsolaris" ; then
-                 CXXFLAGS="-pthreads $CXXFLAGS"
-             elif test "x$host_os" = "xmingw32" ; then
-                 CXXFLAGS="-mthreads $CXXFLAGS"
-             else
-                CXXFLAGS="-pthread $CXXFLAGS"
-             fi
+             case "x$host_os" in
+                 xsolaris )
+                     CXXFLAGS="-pthreads $CXXFLAGS"
+                     break;
+                     ;;
+                 xmingw32 )
+                     CXXFLAGS="-mthreads $CXXFLAGS"
+                     break;
+                     ;;
+                 *android* )
+                     break;
+                     ;;
+                 * )
+                     CXXFLAGS="-pthread $CXXFLAGS"
+                     break;
+                     ;;
+             esac
+
              AC_COMPILE_IFELSE([
                  AC_LANG_PROGRAM(
                      [[@%:@include <boost/thread/thread.hpp>]],
@@ -84,13 +95,23 @@ AC_DEFUN([AX_BOOST_THREAD],
              AC_LANG_POP([C++])
         ])
         if test "x$ax_cv_boost_thread" = "xyes"; then
-           if test "x$host_os" = "xsolaris" ; then
-              BOOST_CPPFLAGS="-pthreads $BOOST_CPPFLAGS"
-           elif test "x$host_os" = "xmingw32" ; then
-              BOOST_CPPFLAGS="-mthreads $BOOST_CPPFLAGS"
-           else
-              BOOST_CPPFLAGS="-pthread $BOOST_CPPFLAGS"
-           fi
+            case "x$host_os" in
+                xsolaris )
+                    BOOST_CPPFLAGS="-pthreads $BOOST_CPPFLAGS"
+                    break;
+                    ;;
+                xmingw32 )
+                    BOOST_CPPFLAGS="-mthreads $BOOST_CPPFLAGS"
+                    break;
+                    ;;
+                *android* )
+                    break;
+                    ;;
+                * )
+                    BOOST_CPPFLAGS="-pthread $BOOST_CPPFLAGS"
+                    break;
+                    ;;
+            esac
 
             AC_SUBST(BOOST_CPPFLAGS)
 
@@ -146,6 +167,9 @@ AC_DEFUN([AX_BOOST_THREAD],
                         break;
                         ;;
                     xmingw32 )
+                        break;
+                        ;;
+                    *android* )
                         break;
                         ;;
                     * )


### PR DESCRIPTION
The android libc, bionic, provides built-in support for pthreads, so no additional linking is necessary.
Setting `-pthread` [breaks the build](https://github.com/protocolbuffers/protobuf/issues/1373).