### PR TITLE
ax_boost_python.m4: fix missing "-l" parameter, resulting into a link…

### DIFF
--- a/m4/ax_boost_python.m4
+++ b/m4/ax_boost_python.m4
@@ -53,7 +53,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 22
+#serial 23
 
 AC_DEFUN([AX_BOOST_PYTHON],
 [AC_REQUIRE([AX_PYTHON_DEVEL])dnl
@@ -109,7 +109,7 @@ if test "$ac_cv_boost_python" = "yes"; then
 BOOST_PYTHON_MODULE(test) { throw "Boost::Python test."; }]], [])],
         [AS_VAR_SET([ax_Lib], [yes])],
         [AS_VAR_SET([ax_Lib], [no])])])
-    AS_VAR_IF([ax_Lib], [yes], [BOOST_PYTHON_LIB=$ax_lib break], [])
+    AS_VAR_IF([ax_Lib], [yes], [BOOST_PYTHON_LIB=-l$ax_lib break], [])
     AS_VAR_POPDEF([ax_Lib])dnl
   done
   AC_SUBST(BOOST_PYTHON_LIB)


### PR DESCRIPTION
… failure when used.

configuring a project with something like:
--with-boost-libdir=/usr/lib/$(DEB_HOST_MULTIARCH) --with-boost-python='boost_python3.7'

tanslates the build into a "boost_python37" link line

checking whether boost_python37 is the correct library... yes

/bin/bash ../libtool  --tag=CXX   --mode=link mpicxx  -Wall -g -O2 -fdebug-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -release 2.3.4  -L/usr/lib/i386-linux-gnu -lboost_system -lpython3.7m -Wl,-z,relro -Wl,-z,now -o libFoundation.la -rpath /usr/lib/i386-linux-gnu libFoundation_la-console.lo libFoundation_la-Counter.lo libFoundation_la-Matrix3.lo libFoundation_la-Quaternion.lo libFoundation_la-vec3.lo libFoundation_la-Timer.lo libFoundation_la-StringUtil.lo libFoundation_la-realdist.lo libFoundation_la-PathSearcher.lo libFoundation_la-Runnable.lo libFoundation_la-PathUtil.lo libFoundation_la-Rng.lo libFoundation_la-BoundingSphere.lo libFoundation_la-BoundingBox.lo libFoundation_la-cube_eq.lo -lboost_filesystem boost_python37 -lpython3.7m -lmpi++ -lmpi

note the missing "-l" on python, while it is there for the filesystem link.