### PR TITLE
m4/ax_boost_base.m4: Fix debian multiarch_libsubdir path for arch armv7l

### DIFF
--- a/m4/ax_boost_base.m4
+++ b/m4/ax_boost_base.m4
@@ -33,7 +33,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 47
+#serial 48
 
 # example boost program (need to pass version)
 m4_define([_AX_BOOST_BASE_PROGRAM],
@@ -123,6 +123,7 @@ AC_DEFUN([_AX_BOOST_BASE_RUNDETECT],[
     dnl are almost assuredly the ones desired.
     AS_CASE([${host_cpu}],
       [i?86],[multiarch_libsubdir="lib/i386-${host_os}"],
+      [armv7l],[multiarch_libsubdir="lib/arm-${host_os}"],
       [multiarch_libsubdir="lib/${host_cpu}-${host_os}"]
     )
 


### PR DESCRIPTION
Without this patch, building on an RPI4 ends up with
BOOST_LDFLAGS=-L/usr/lib while libs are actually under
/usr/lib/arm-linux-gnueabihf, and configure will later file during
AX_BOOST_THREAD macro.