### PR TITLE
ax_gcc_func_attribute: Revise the detection of unknown attributes

### DIFF
--- a/m4/ax_gcc_func_attribute.m4
+++ b/m4/ax_gcc_func_attribute.m4
@@ -228,7 +228,7 @@ AC_DEFUN([AX_GCC_FUNC_ATTRIBUTE], [
             dnl GCC doesn't exit with an error if an unknown attribute is
             dnl provided but only outputs a warning, so accept the attribute
             dnl only if no warning were issued.
-            [AS_IF([test -s conftest.err],
+            [AS_IF([grep -- -Wattributes conftest.err],
                 [AS_VAR_SET([ac_var], [no])],
                 [AS_VAR_SET([ac_var], [yes])])],
             [AS_VAR_SET([ac_var], [no])])


### PR DESCRIPTION
GCC outputs a warning when Wstrict-prototypes is on, in such case the
attribute detection always fails even if the attribute is actually
supported. This change checks for the "-Wattributes" warning in
conftest.err instead of the existence of the file.