### PR TITLE
ax_gcc_func_attribute.m4: test fails for the fallthrough attribute with clang

### DIFF
--- a/m4/ax_gcc_func_attribute.m4
+++ b/m4/ax_gcc_func_attribute.m4
@@ -78,7 +78,7 @@
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 12
+#serial 13
 
 AC_DEFUN([AX_GCC_FUNC_ATTRIBUTE], [
     AS_VAR_PUSHDEF([ac_var], [ax_cv_have_func_attribute_$1])
@@ -133,7 +133,7 @@ AC_DEFUN([AX_GCC_FUNC_ATTRIBUTE], [
                     int foo( void ) __attribute__(($1));
                 ],
                 [fallthrough], [
-                    int foo( void ) {switch (0) { case 1: __attribute__(($1)); case 2: break ; }};
+                    void foo( int x ) {switch (x) { case 1: __attribute__(($1)); case 2: break ; }};
                 ],
                 [flatten], [
                     int foo( void ) __attribute__(($1));


### PR DESCRIPTION
The test for the fallthrough attribute fails due to other compiler
warnings when using clang.  The following warnings are generated:

   warning: no case matching constant switch condition '0'
   warning: control reaches end of non-void function [-Wreturn-type]

Because of these additional warnings, the test always results in a
failure for the fallthrough attribute.

Update ax_gcc_func_attribute.m4 to eliminate the warnings that are
masking the test for the fallthrough attribute.

Note, tested the entire suite of attribute tests using clang and only
the fallthrough test contained warnings that were not related to the
the attribute being tested.