### PR TITLE
Suppress C++ warnings in `AX_HAVE_POLL`.

### DIFF
--- a/m4/ax_have_poll.m4
+++ b/m4/ax_have_poll.m4
@@ -41,8 +41,20 @@ AC_DEFUN([AX_HAVE_POLL], [dnl
   AC_CACHE_VAL([ax_cv_have_poll], [dnl
     AC_LINK_IFELSE([dnl
       AC_LANG_PROGRAM(
-        [#include <poll.h>],
-        [int rc; rc = poll((struct pollfd *)(0), 0, 0);])],
+        [dnl
+#include <poll.h>
+#if defined(__cplusplus)
+#include <stddef.h>
+#endif],
+        [dnl
+#if defined(__cplusplus)
+pollfd *pfd = NULL;
+#else
+struct pollfd *pfd = 0;
+#endif
+int rc = poll(pfd, 0, 0);
+/* Suppress warning for unused rc. */
+return rc - rc;])],
       [ax_cv_have_poll=yes],
       [ax_cv_have_poll=no])])
   AS_IF([test "${ax_cv_have_poll}" = "yes"],
@@ -58,11 +70,24 @@ AC_DEFUN([AX_HAVE_PPOLL], [dnl
       AC_LANG_PROGRAM(
         [dnl
 #include <poll.h>
-#include <signal.h>],
+#include <signal.h>
+#if defined(__cplusplus)
+#include <stddef.h>
+#endif],
         [dnl
-int rc;
-rc = poll((struct pollfd *)(0), 0, 0);
-rc = ppoll((struct pollfd *)(0), 0, (struct timespec const *)(0), (sigset_t const *)(0));])],
+#if defined(__cplusplus)
+pollfd *pfd = NULL;
+timespec const *ts = NULL;
+sigset_t const *sst = NULL;
+#else
+struct pollfd *pfd = 0;
+struct timespec const *ts = 0;
+sigset_t const *sst = 0;
+#endif
+int rc = poll(pfd, 0, 0);
+rc += ppoll(pfd, 0, ts, sst);
+/* Suppress warning for unused rc. */
+return rc - rc;])],
       [ax_cv_have_ppoll=yes],
       [ax_cv_have_ppoll=no])])
   AS_IF([test "${ax_cv_have_ppoll}" = "yes"],


### PR DESCRIPTION
The `AX_HAVE_POLL` macro always fail in C++ when I enable gcc's stricter
warning options and also `-Werror`.

I get these warnings (elevated to errors by `-Werror`):

    conftest.cpp: In function 'int main()':
    conftest.cpp:35:20: error: redundant class-key 'struct' in reference to 'struct pollfd' [-Werror=redundant-tags]
       35 | int rc; rc = poll((struct pollfd *)(0), 0, 0);
          |                    ^~~~~~
          |                    ------
    conftest.cpp:35:38: error: use of old-style cast to 'struct pollfd*' [-Werror=old-style-cast]
       35 | int rc; rc = poll((struct pollfd *)(0), 0, 0);
          |                                      ^
          |                   -
          |                   static_cast<    -
          |                                   > ( )
    conftest.cpp:35:5: error: variable 'rc' set but not used [-Werror=unused-but-set-variable]
       35 | int rc; rc = poll((struct pollfd *)(0), 0, 0);
          |     ^~

I have a suggested fix (see attached), which may also fix similar issues
in C.  But there is a cost: I couldn't find any perfectly portable way
to produce a null pointer _without_ triggering a warning.

So I caved and used the old `NULL` macro from the (in C++) archaic
`<stddef.h>`.  I figured if you don't have _that,_ good luck trying to
compile C++ code anyway!  Without that, I still get a warning for
using `0` as a null pointer.

There's probably some better way of dealing with this that I'm not aware
of.  So see this as a starting point.