### PR TITLE
Modernize ax_check_sign.

### DIFF
--- a/m4/ax_check_sign.m4
+++ b/m4/ax_check_sign.m4
@@ -35,16 +35,18 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([VL_CHECK_SIGN], [AX_CHECK_SIGN])
 AC_DEFUN([AX_CHECK_SIGN], [
  typename=`echo $1 | sed "s/@<:@^a-zA-Z0-9_@:>@/_/g"`
  AC_CACHE_CHECK([whether $1 is signed], ax_cv_decl_${typename}_signed, [
-   AC_TRY_COMPILE([$4],
-     [ int foo @<:@ 1 - 2 * !((($1) -1) < 0) @:>@ ],
+   AC_COMPILE_IFELSE(
+     [AC_LANG_PROGRAM([[$4]],
+       [[ int foo @<:@ 1 - 2 * !((($1) -1) < 0) @:>@ ]])],
      [ eval "ax_cv_decl_${typename}_signed=\"yes\"" ],
-     [ eval "ax_cv_decl_${typename}_signed=\"no\"" ])])
+     [ eval "ax_cv_decl_${typename}_signed=\"no\"" ])
+ ])
  symbolname=`echo $1 | sed "s/@<:@^a-zA-Z0-9_@:>@/_/g" | tr "a-z" "A-Z"`
  if eval "test \"\${ax_cv_decl_${typename}_signed}\" = \"yes\""; then
    $2


### PR DESCRIPTION
This changes the obsolete AC_TRY_COMPILE to the newer
AC_COMPILE_PROGRAM.