### PR TITLE
AX_CC_MAXOPT: adjust to new way of testing if var is set

### DIFF
--- a/m4/ax_cc_maxopt.m4
+++ b/m4/ax_cc_maxopt.m4
@@ -55,7 +55,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 18
+#serial 19
 
 AC_DEFUN([AX_CC_MAXOPT],
 [
@@ -67,7 +67,7 @@ AC_ARG_ENABLE(portable-binary, [AS_HELP_STRING([--enable-portable-binary], [disa
 	acx_maxopt_portable=$enableval, acx_maxopt_portable=no)
 
 # Try to determine "good" native compiler flags if none specified via CFLAGS
-if test "$ac_test_CFLAGS" != "set"; then
+if test "x$ac_test_CFLAGS" = "x"; then
   case $ax_cv_c_compiler_vendor in
     dec) CFLAGS="$CFLAGS -newc -w0 -O5 -ansi_alias -ansi_args -fp_reorder -tune host"
 	 if test "x$acx_maxopt_portable" = xno; then


### PR DESCRIPTION
autoconf 2.70 changed default value set in $ac_test_* from "set" to "y"
see https://git.savannah.gnu.org/cgit/autoconf.git/commit/?id=76754e0
instead of checking for specific value, just check if var is empty