### PR TITLE
AX_COMPILER_VENDOR: Add support for the NVIDIA HPC Compiler

### DIFF
--- a/m4/ax_cc_maxopt.m4
+++ b/m4/ax_cc_maxopt.m4
@@ -143,6 +143,10 @@ if test "$ac_test_CFLAGS" != "set"; then
         fi
 	;;
 
+    nvhpc)
+     # default optimization flags for nvhpc
+     CFLAGS="$CFLAGS -O3"
+
     gnu)
      # default optimization flags for gcc on all systems
      CFLAGS="$CFLAGS -O3 -fomit-frame-pointer"

--- a/m4/ax_compiler_vendor.m4
+++ b/m4/ax_compiler_vendor.m4
@@ -12,10 +12,11 @@
 #   returned in the cache variable $ax_cv_c_compiler_vendor for C,
 #   $ax_cv_cxx_compiler_vendor for C++ or $ax_cv_fc_compiler_vendor for
 #   (modern) Fortran.  The value is one of "intel", "ibm", "pathscale",
-#   "clang" (LLVM), "cray", "fujitsu", "sdcc", "sx", "portland" (PGI), "gnu"
-#   (GCC), "sun" (Oracle Developer Studio), "hp", "dec", "borland",
-#   "comeau", "kai", "lcc", "sgi", "microsoft", "metrowerks", "watcom",
-#   "tcc" (Tiny CC) or "unknown" (if the compiler cannot be determined).
+#   "clang" (LLVM), "cray", "fujitsu", "sdcc", "sx",
+#   "nvhpc" (NVIDIA HPC Compiler), "portland" (PGI), "gnu" (GCC),
+#   "sun" (Oracle Developer Studio), "hp", "dec", "borland", "comeau", "kai",
+#   "lcc", "sgi", "microsoft", "metrowerks", "watcom", "tcc" (Tiny CC) or
+#   "unknown" (if the compiler cannot be determined).
 #
 #   To check for a Fortran compiler, you must first call AC_FC_PP_SRCEXT
 #   with an appropriate preprocessor-enabled extension.  For example:
@@ -78,6 +79,7 @@ AC_DEFUN([AX_COMPILER_VENDOR], [dnl
 		fujitsu:	__FUJITSU
 		sdcc:		SDCC,__SDCC
 		sx:		_SX
+		nvhpc:		__NVCOMPILER
 		portland:	__PGI
 		gnu:		__GNUC__
 		sun:		__SUNPRO_C,__SUNPRO_CC,__SUNPRO_F90,__SUNPRO_F95

--- a/m4/ax_compiler_version.m4
+++ b/m4/ax_compiler_version.m4
@@ -442,6 +442,20 @@ AC_DEFUN([_AX_COMPILER_VERSION_WATCOM],[dnl
   ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="$_ax_[]_AC_LANG_ABBREV[]_compiler_version_major.$_ax_[]_AC_LANG_ABBREV[]_compiler_version_minor"
   ])
 
+# for NVHPC
+AC_DEFUN([_AX_COMPILER_VERSION_NVHPC],[
+  AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_major,
+    __NVCOMPILER_MAJOR__,,
+    AC_MSG_FAILURE([[[$0]] unknown nvhpc major]))
+  AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_minor,
+    __NVCOMPILER_MINOR__,,
+    AC_MSG_FAILURE([[[$0]] unknown nvhpc minor]))
+  AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_patch,
+    [__NVCOMPILER_PATCHLEVEL__],,
+    AC_MSG_FAILURE([[[$0]] unknown nvhpc patch level]))
+  ax_cv_[]_AC_LANG_ABBREV[]_compiler_version="$_ax_[]_AC_LANG_ABBREV[]_compiler_version_major.$_ax_[]_AC_LANG_ABBREV[]_compiler_version_minor.$_ax_[]_AC_LANG_ABBREV[]_compiler_version_patch"
+  ])
+
 # for PGI
 AC_DEFUN([_AX_COMPILER_VERSION_PORTLAND],[
   AC_COMPUTE_INT(_ax_[]_AC_LANG_ABBREV[]_compiler_version_major,
@@ -521,6 +535,7 @@ AC_DEFUN([AX_COMPILER_VERSION],[dnl
 	[microsoft],[_AX_COMPILER_VERSION_MICROSOFT],
 	[metrowerks],[_AX_COMPILER_VERSION_METROWERKS],
 	[watcom],[_AX_COMPILER_VERSION_WATCOM],
+	[nvhpc],[_AX_COMPILER_VERSION_NVHPC],
 	[portland],[_AX_COMPILER_VERSION_PORTLAND],
 	[tcc],[_AX_COMPILER_VERSION_TCC],
 	[sdcc],[_AX_COMPILER_VERSION_SDCC],


### PR DESCRIPTION
This specifically detects the NVIDIA HPC compiler.  The "nvhpc"
label is explicitly chosen here insted of "nvidia" to distinguish
from other NVIDIA compilers (cuda, etc.)