### PR TITLE
VALGRIND_CHECK_RULE: Correct spelling of $(addprefix)

### DIFF
--- a/m4/ax_valgrind_check.m4
+++ b/m4/ax_valgrind_check.m4
@@ -231,7 +231,7 @@ A''M_DISTCHECK_CONFIGURE_FLAGS += --disable-valgrind
 MOSTLYCLEANFILES ?=
 MOSTLYCLEANFILES += $(valgrind_log_files)
 
-.PHONY: check-valgrind $(add-prefix check-valgrind-,$(valgrind_tools))
+.PHONY: check-valgrind $(addprefix check-valgrind-,$(valgrind_tools))
 ']
 
 	AC_SUBST([VALGRIND_CHECK_RULES])


### PR DESCRIPTION
VALGRIND_CHECK_RULE used `$(add-prefix)` instead of `$(addprefix)`:

https://www.gnu.org/software/make/manual/html_node/File-Name-Functions.html#index-file-name-prefix_002c-adding