### PR TITLE
AX_VALGRIND_CHECK: Fix "nothing to be done".

### DIFF
--- a/m4/ax_valgrind_check.m4
+++ b/m4/ax_valgrind_check.m4
@@ -77,11 +77,11 @@ AC_DEFUN([AX_VALGRIND_DFLT],[
 	m4_define([en_dflt_valgrind_$1], [$2])
 ])dnl
 
-AM_EXTRA_RECURSIVE_TARGETS([check-valgrind])
-m4_foreach([vgtool], [valgrind_tool_list],
-	[AM_EXTRA_RECURSIVE_TARGETS([check-valgrind-]vgtool)])
-
 AC_DEFUN([AX_VALGRIND_CHECK],[
+	AM_EXTRA_RECURSIVE_TARGETS([check-valgrind])
+	m4_foreach([vgtool], [valgrind_tool_list],
+		[AM_EXTRA_RECURSIVE_TARGETS([check-valgrind-]vgtool)])
+
 	dnl Check for --enable-valgrind
 	AC_ARG_ENABLE([valgrind],
 	              [AS_HELP_STRING([--enable-valgrind], [Whether to enable Valgrind on the unit tests])],

--- a/m4/ax_valgrind_check.m4
+++ b/m4/ax_valgrind_check.m4
@@ -177,7 +177,7 @@ valgrind_quiet_ = $(valgrind_quiet_$(AM_DEFAULT_VERBOSITY))
 valgrind_quiet_0 = --quiet
 valgrind_v_use   = $(valgrind_v_use_$(V))
 valgrind_v_use_  = $(valgrind_v_use_$(AM_DEFAULT_VERBOSITY))
-valgrind_v_use_0 = @echo "  USE   " $(patsubst check-valgrind-%-am,%,$''@):;
+valgrind_v_use_0 = @echo "  USE   " $(patsubst check-valgrind-%-local,%,$''@):;
 
 # Support running with and without libtool.
 ifneq ($(LIBTOOL),)
@@ -187,7 +187,7 @@ valgrind_lt =
 endif
 
 # Use recursive makes in order to ignore errors during check
-check-valgrind-am:
+check-valgrind-local:
 ifeq ($(VALGRIND_ENABLED),yes)
 	$(A''M_V_at)$(MAKE) $(AM_MAKEFLAGS) -k \
 		$(foreach tool, $(valgrind_enabled_tools), check-valgrind-$(tool))
@@ -207,7 +207,7 @@ VALGRIND_LOG_COMPILER = \
 	$(VALGRIND) $(VALGRIND_SUPPRESSIONS) --error-exitcode=1 $(VALGRIND_FLAGS)
 
 define valgrind_tool_rule
-check-valgrind-$(1)-am:
+check-valgrind-$(1)-local:
 ifeq ($$(VALGRIND_ENABLED)-$$(ENABLE_VALGRIND_$(1)),yes-yes)
 ifneq ($$(TESTS),)
 	$$(valgrind_v_use)$$(MAKE) check-TESTS \

--- a/m4/ax_valgrind_check.m4
+++ b/m4/ax_valgrind_check.m4
@@ -65,7 +65,7 @@
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 17
+#serial 18
 
 dnl Configured tools
 m4_define([valgrind_tool_list], [[memcheck], [helgrind], [drd], [sgcheck]])


### PR DESCRIPTION
Correct two problems in `AX_VALGRIND_CHECK`:

1. Automake did not generate recursive rules for each valgrind tool when using an installed copy of `ax_valgrind_check.m4` (e.g. `/usr/share/aclocal/ax_valgrind_check.m4`).
2. The recursive rules were incorrectly named, causing "`make check-valgrind`" to have a "_nothing to be done_" result.  Automake expects recursive rules declared through `AM_EXTRA_RECURSIVE_TARGETS()` to end with `-local`, not `-am`.  Rename the rules, accordingly.  See the Automake manual section for "[Recursing subdirectories](https://www.gnu.org/software/automake/manual/automake.html#Subdirectories)" for details.