### PR TITLE
AX_CC_FOR_BUILD: deprecate in favor of AX_PROG_CC_FOR_BUILD

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,8 @@
 
 * Noteworthy changes in release ?.? (????-??-??) [?]
 
+  AX_CC_FOR_BUILD was deprecated in favor of AX_PROG_CC_FOR_BUILD.
+
 * Noteworthy changes in release 2021.02.19 (2021-02-19) [stable]
 
   The macros AX_CHECK_PCRE2 and AX_PROG_ROBOT have been added. Many other

--- a/m4/ax_cc_for_build.m4
+++ b/m4/ax_cc_for_build.m4
@@ -10,6 +10,9 @@
 #
 #   Find a build-time compiler. Sets CC_FOR_BUILD and EXEEXT_FOR_BUILD.
 #
+#   AX_CC_FOR_BUILD is deprecated; it expands into AX_PROG_CC_FOR_BUILD which
+#   renames EXEEXT_FOR_BUILD to BUILD_EXEEXT.
+#
 # LICENSE
 #
 #   Copyright (c) 2010 Reuben Thomas <rrt@sc3d.org>
@@ -41,37 +44,12 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 3
+#serial 4
 
-dnl Get a default for CC_FOR_BUILD to put into Makefile.
 AC_DEFUN([AX_CC_FOR_BUILD],
-[# Put a plausible default for CC_FOR_BUILD in Makefile.
-if test -z "$CC_FOR_BUILD"; then
-  if test "x$cross_compiling" = "xno"; then
-    CC_FOR_BUILD='$(CC)'
-  else
-    CC_FOR_BUILD=gcc
-  fi
-fi
-AC_SUBST(CC_FOR_BUILD)
-# Also set EXEEXT_FOR_BUILD.
-if test "x$cross_compiling" = "xno"; then
-  EXEEXT_FOR_BUILD='$(EXEEXT)'
-else
-  AC_CACHE_CHECK([for build system executable suffix], bfd_cv_build_exeext,
-    [rm -f conftest*
-     echo 'int main () { return 0; }' > conftest.c
-     bfd_cv_build_exeext=
-     ${CC_FOR_BUILD} -o conftest conftest.c 1>&5 2>&5
-     for file in conftest.*; do
-       case $file in
-       *.c | *.o | *.obj | *.ilk | *.pdb) ;;
-       *) bfd_cv_build_exeext=`echo $file | sed -e s/conftest//` ;;
-       esac
-     done
-     rm -f conftest*
-     test x"${bfd_cv_build_exeext}" = x && bfd_cv_build_exeext=no])
-  EXEEXT_FOR_BUILD=""
-  test x"${bfd_cv_build_exeext}" != xno && EXEEXT_FOR_BUILD=${bfd_cv_build_exeext}
-fi
+[dnl
+m4_warn([obsolete], [$0 is deprecated, please use AX_PROG_CC_FOR_BUILD instead])
+AC_REQUIRE([AX_PROG_CC_FOR_BUILD])
+dnl Backwards compatibility.
+EXEEXT_FOR_BUILD=$BUILD_EXEEXT
 AC_SUBST(EXEEXT_FOR_BUILD)])dnl


### PR DESCRIPTION
The AX_PROG_CC_FOR_BUILD has seen a lot more updates than
AX_CC_FOR_BUILD, and is generally way more complete.  The latter
hardcoded `gcc` as the native compiler fallback and lacks any of
the standard $build- prefix searches.

It also uses non-standard cache vars -- it's using the bfd_cv_xxx
namespace instead of the ax_cv_xxx namespace everything else does.

Otherwise, the macros largely have the same intention: to find a
compiler for the build system, and setup the exe extension.  So
deprecate AX_CC_FOR_BUILD and have it redirect automatically.