### PR TITLE
updated test for whether CFLAGS was set by the user

### DIFF
--- a/m4/ax_cc_maxopt.m4
+++ b/m4/ax_cc_maxopt.m4
@@ -67,7 +67,7 @@ AC_ARG_ENABLE(portable-binary, [AS_HELP_STRING([--enable-portable-binary], [disa
 	acx_maxopt_portable=$enableval, acx_maxopt_portable=no)
 
 # Try to determine "good" native compiler flags if none specified via CFLAGS
-if test "$ac_test_CFLAGS" != "set"; then
+if test "x$ac_test_CFLAGS" != "xset" -a "x$ac_test_CFLAGS" != "xy"; then
   case $ax_cv_c_compiler_vendor in
     dec) CFLAGS="$CFLAGS -newc -w0 -O5 -ansi_alias -ansi_args -fp_reorder -tune host"
 	 if test "x$acx_maxopt_portable" = xno; then

--- a/m4/ax_cc_maxopt.m4
+++ b/m4/ax_cc_maxopt.m4
@@ -55,7 +55,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 18
+#serial 19
 
 AC_DEFUN([AX_CC_MAXOPT],
 [


### PR DESCRIPTION
This was [changed in 2015](https://git.savannah.gnu.org/cgit/autoconf.git/commit/?id=76754e04fce5f6a7701bec57b057020585df2ae3), so we have to test for `"y"` here for recent autoconf versions.  Otherwise `configure` will end up ignoring the user's `CFLAGS`

(I added `"x"` prefix to the `"$..."` string in the test out of my usual paranoia in case the shell variable contains some special character that confuses `sh`.)

See also https://github.com/NanoComp/meep/issues/1934