### PR TITLE
AX_CC_MAXOPT: Fix nvhpc case

### DIFF
--- a/m4/ax_cc_maxopt.m4
+++ b/m4/ax_cc_maxopt.m4
@@ -146,6 +146,7 @@ if test "x$ac_test_CFLAGS" = "x"; then
     nvhpc)
      # default optimization flags for nvhpc
      CFLAGS="$CFLAGS -O3"
+     ;;
 
     gnu)
      # default optimization flags for gcc on all systems


### PR DESCRIPTION
Missing ;; in the ax_cv_c_compiler_vendor case statement causing syntax error with libffi configure:
```
  line y: syntax error near unexpected token `)'
  line y: `    gnu)'
```

Error was identified building libffi:
- https://github.com/libffi/libffi/issues/692

Raised as savannah patch:
- https://savannah.gnu.org/patch/index.php?10186