### PR TITLE
ax_prog_cc_for_build: Properly restore ac_cv_c_compiler_gnu

### DIFF
--- a/m4/ax_prog_cc_for_build.m4
+++ b/m4/ax_prog_cc_for_build.m4
@@ -32,7 +32,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 20
+#serial 21
 
 AU_ALIAS([AC_PROG_CC_FOR_BUILD], [AX_PROG_CC_FOR_BUILD])
 AC_DEFUN([AX_PROG_CC_FOR_BUILD], [dnl
@@ -89,16 +89,16 @@ AC_LANG_PUSH([C])
 dnl The pushdef([ac_cv_c_compiler_gnu], ...) currently does not cover
 dnl the use of this variable in _AC_LANG_COMPILER_GNU called by
 dnl AC_PROG_CC. Unset this cache variable temporarily as a workaround.
-was_set_ac_cv_c_compiler_gnu=${[ac_cv_c_compiler_gnu]+y}
-AS_IF([test ${was_set_ac_cv_c_compiler_gnu}],
-    [saved_ac_cv_c_compiler_gnu=$[ac_cv_c_compiler_gnu]
+was_set_c_compiler_gnu=${[ac_cv_c_compiler_gnu]+y}
+AS_IF([test ${was_set_c_compiler_gnu}],
+    [saved_c_compiler_gnu=$[ac_cv_c_compiler_gnu]
     AS_UNSET([[ac_cv_c_compiler_gnu]])])
 
 AC_PROG_CC
 
 dnl Restore ac_cv_c_compiler_gnu
-AS_IF([test ${was_set_ac_cv_c_compiler_gnu}],
-  [[ac_cv_c_compiler_gnu]=saved_ac_cv_c_compiler_gnu])
+AS_IF([test ${was_set_c_compiler_gnu}],
+  [[ac_cv_c_compiler_gnu]=$[saved_c_compiler_gnu]])
 
 _AC_COMPILER_EXEEXT
 _AC_COMPILER_OBJEXT


### PR DESCRIPTION
The ac_cv_c_compiler_gnu wasn't properly restored to original
state (f.e. yes), but value of the "save" variable was used:

ac_cv_c_compiler_gnu=${ac_cv_c_compiler_gnu=saved_ac_cv_c_compiler_gnu}

Additionally, we don't need to cache the saved_ac_cv_c_compiler_gnu
and was_set_ac_cv_c_compiler_gnu, so remove the ac_cv_ from their names.

This would not manifest on a single run, but any repeated run with cache
file (./configure -C) would be broken.