### PR TITLE
ax_check_icu: bump serial and update after icu-config deprecation

### DIFF
--- a/m4/ax_check_icu.m4
+++ b/m4/ax_check_icu.m4
@@ -19,7 +19,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_CHECK_ICU], [AX_CHECK_ICU])
 AC_DEFUN([AX_CHECK_ICU], [
@@ -29,13 +29,19 @@ AC_DEFUN([AX_CHECK_ICU], [
     AC_PATH_PROG(ICU_CONFIG, icu-config, no)
   fi
 
-  if test "$ICU_CONFIG" = "no" ; then
-    echo "*** The icu-config script could not be found. Make sure it is"
-    echo "*** in your path, and that taglib is properly installed."
-    echo "*** Or see http://ibm.com/software/globalization/icu/"
-  else
+  if test -z "$PKG_CONFIG"; then
+    AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
+  fi
+
+  if test "$ICU_CONFIG" = "no" && test "$PKG_CONFIG" = "no" ; then
+    echo "*** Neither icu-config nor pkg-config could not be found."
+    echo "*** Make sure one of them is in your path, and that taglib"
+    echo "*** is properly installed. Or see https://icu.unicode.org/"
+  fi
+
+  if test "$ICU_CONFIG" != "no" ; then
     ICU_VERSION=`$ICU_CONFIG --version`
-    AC_MSG_CHECKING(for ICU >= $1)
+    AC_MSG_CHECKING(for ICU >= $1 via icu-config)
         VERSION_CHECK=`expr $ICU_VERSION \>\= $1`
         if test "$VERSION_CHECK" = "1" ; then
             AC_MSG_RESULT(yes)
@@ -63,16 +69,47 @@ AC_DEFUN([AX_CHECK_ICU], [
             ICU_LIBS=""
             ## If we have a custom action on failure, don't print errors, but
             ## do set a variable so people can do so.
-            ifelse([$3], ,echo "can't find ICU >= $1",)
+            ifelse([$3], ,echo "can't find ICU >= $1 via icu-config",)
         fi
-
-        AC_SUBST(ICU_CPPFLAGS)
-        AC_SUBST(ICU_CFLAGS)
-        AC_SUBST(ICU_CXXFLAGS)
-        AC_SUBST(ICU_LIBS)
   fi
 
-  if test $succeeded = yes; then
+  if test "$succeeded" != "yes" && test "$PKG_CONFIG" != "no" ; then
+    AC_MSG_CHECKING(for ICU >= $1 via pkg-config)
+        if $PKG_CONFIG --atleast-version=$1 icu-i18n ; then
+            AC_MSG_RESULT(yes)
+            succeeded=yes
+
+            AC_MSG_CHECKING(ICU_CPPFLAGS)
+            ICU_CPPFLAGS=`$PKG_CONFIG --variable=CPPFLAGS icu-i18n`
+            AC_MSG_RESULT($ICU_CPPFLAGS)
+
+            AC_MSG_CHECKING(ICU_CFLAGS)
+            ICU_CFLAGS=`$PKG_CONFIG --variable=CFLAGS icu-i18n`
+            AC_MSG_RESULT($ICU_CFLAGS)
+
+            AC_MSG_CHECKING(ICU_CXXFLAGS)
+            ICU_CXXFLAGS=`$PKG_CONFIG --variable=CXXFLAGS icu-i18n`
+            AC_MSG_RESULT($ICU_CXXFLAGS)
+
+            AC_MSG_CHECKING(ICU_LIBS)
+            ICU_LIBS=`$PKG_CONFIG --libs icu-i18n`
+            AC_MSG_RESULT($ICU_LIBS)
+        else
+            ICU_CPPFLAGS=""
+            ICU_CFLAGS=""
+            ICU_CXXFLAGS=""
+            ICU_LIBS=""
+            ## If we have a custom action on failure, don't print errors, but
+            ## do set a variable so people can do so.
+            ifelse([$3], ,echo "can't find ICU >= $1 via pkg-config",)
+        fi
+  fi
+
+  if test "$succeeded" = "yes"; then
+     AC_SUBST(ICU_CPPFLAGS)
+     AC_SUBST(ICU_CFLAGS)
+     AC_SUBST(ICU_CXXFLAGS)
+     AC_SUBST(ICU_LIBS)
      ifelse([$2], , :, [$2])
   else
      ifelse([$3], , AC_MSG_ERROR([Library requirements (ICU) not met.]), [$3])


### PR DESCRIPTION
The changes in this PR are primarily due to @TinoDidriksen and @unhammer that they did for [hfst](https://github.com/hfst/hfst) at https://github.com/hfst/hfst/blob/master/m4/ax_check_icu.m4

Additionally, I have bumped the serial number to 8 and updated the broken link on line 35 pointing to http://ibm.com/software/globalization/icu/.
