### PR TITLE
Clang 16 fixes

### DIFF
--- a/m4/ax_add_fortify_source.m4
+++ b/m4/ax_add_fortify_source.m4
@@ -36,7 +36,7 @@
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 4
+#serial 5
 
 AC_DEFUN([AX_ADD_FORTIFY_SOURCE],[
     ac_save_cflags=$CFLAGS
@@ -57,7 +57,7 @@ AC_DEFUN([AX_ADD_FORTIFY_SOURCE],[
             AC_LANG_SOURCE([[
                 #define _FORTIFY_SOURCE 2
                 #include <string.h>
-                int main() {
+                int main(void) {
                     char *s = " ";
                     strcpy(s, "x");
                     return strlen(s)-1;

--- a/m4/ax_c99_inline.m4
+++ b/m4/ax_c99_inline.m4
@@ -21,7 +21,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 8
+#serial 9
 
 AC_DEFUN([AX_C99_INLINE], [
 	AC_MSG_CHECKING([whether the compiler supports C99 inline functions])
@@ -36,8 +36,8 @@ AC_DEFUN([AX_C99_INLINE], [
 	dnl	translation units that could require the definition.
 	AC_LINK_IFELSE(
 		AC_LANG_SOURCE([
-			inline void* foo() { foo(); return &foo; }
-			int main() { return foo() != 0;}
+			inline void* foo(void) { foo(); return &foo; }
+			int main(void) { return foo() != 0;}
 			]),
 
 		dnl the invalid source compiled, so the inline keyword does not work
@@ -47,8 +47,8 @@ AC_DEFUN([AX_C99_INLINE], [
 		dnl Secondary test of valid source.
 		AC_LINK_IFELSE(
 			AC_LANG_SOURCE([
-				extern inline void* foo() { foo(); return &foo; }
-				int main() { return foo() != 0;}
+				extern inline void* foo(void) { foo(); return &foo; }
+				int main(void) { return foo() != 0;}
 				]),
 
 			AC_MSG_RESULT([yes])

--- a/m4/ax_c_var_func.m4
+++ b/m4/ax_c_var_func.m4
@@ -50,14 +50,14 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 12
+#serial 13
 
 AU_ALIAS([AC_C_VAR_FUNC], [AX_C_VAR_FUNC])
 AC_DEFUN([AX_C_VAR_FUNC],
 [AC_REQUIRE([AC_PROG_CC])
 AC_CACHE_CHECK(whether $CC recognizes __func__, ac_cv_c_var_func,
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([],
-[[int main() {
+[[int main(void) {
 char *s = __func__;
 }]])],
 [ac_cv_c_var_func=yes],

--- a/m4/ax_check_posix_regcomp.m4
+++ b/m4/ax_check_posix_regcomp.m4
@@ -21,7 +21,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AG_CHECK_POSIX_REGCOMP], [AX_CHECK_POSIX_REGCOMP])
 AC_DEFUN([AX_CHECK_POSIX_REGCOMP],[
@@ -29,7 +29,7 @@ AC_DEFUN([AX_CHECK_POSIX_REGCOMP],[
   AC_CACHE_VAL([ax_cv_posix_regcomp],[
   AC_RUN_IFELSE([AC_LANG_SOURCE([[#include <sys/types.h>
 #include <regex.h>
-int main() {
+int main(void) {
   int flags = REG_EXTENDED|REG_ICASE|REG_NEWLINE;
   regex_t  re;
   if (regcomp( &re, "^.*$", flags ) != 0)

--- a/m4/ax_check_posix_sysinfo.m4
+++ b/m4/ax_check_posix_sysinfo.m4
@@ -20,14 +20,14 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AG_CHECK_POSIX_SYSINFO], [AX_CHECK_POSIX_SYSINFO])
 AC_DEFUN([AX_CHECK_POSIX_SYSINFO],[
   AC_MSG_CHECKING([whether sysinfo(2) is POSIX])
   AC_CACHE_VAL([ax_cv_posix_sysinfo],[
   AC_RUN_IFELSE([AC_LANG_SOURCE([[#include <sys/systeminfo.h>
-int main() { char z[ 256 ];
+int main(void) { char z[ 256 ];
 long sz = sysinfo( SI_SYSNAME, z, sizeof( z ));
 return (sz > 0) ? 0 : 1; }]])],[ax_cv_posix_sysinfo=yes],[ax_cv_posix_sysinfo=no],[ax_cv_posix_sysinfo=no]
   ) # end of TRY_RUN]) # end of CACHE_VAL

--- a/m4/ax_check_strftime.m4
+++ b/m4/ax_check_strftime.m4
@@ -19,13 +19,14 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AG_CHECK_STRFTIME], [AX_CHECK_STRFTIME])
 AC_DEFUN([AX_CHECK_STRFTIME],[
   AC_MSG_CHECKING([whether strftime() works])
   AC_CACHE_VAL([ax_cv_strftime],[
   AC_RUN_IFELSE([AC_LANG_SOURCE([[#include <time.h>
+#include <string.h>
 char t_buf[ 64 ];
 int main() {
   static const char z[] = "Thursday Aug 28 240";

--- a/m4/ax_check_uname_syscall.m4
+++ b/m4/ax_check_uname_syscall.m4
@@ -19,14 +19,14 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AG_CHECK_UNAME_SYSCALL], [AX_CHECK_UNAME_SYSCALL])
 AC_DEFUN([AX_CHECK_UNAME_SYSCALL],[
   AC_MSG_CHECKING([whether uname(2) is POSIX])
   AC_CACHE_VAL([ax_cv_uname_syscall],[
   AC_RUN_IFELSE([AC_LANG_SOURCE([[#include <sys/utsname.h>
-int main() { struct utsname unm;
+int main(void) { struct utsname unm;
 return uname( &unm ); }]])],[ax_cv_uname_syscall=yes],[ax_cv_uname_syscall=no],[ax_cv_uname_syscall=no]
   ) # end of TRY_RUN]) # end of CACHE_VAL
 

--- a/m4/ax_cpu_freq.m4
+++ b/m4/ax_cpu_freq.m4
@@ -19,16 +19,18 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 8
+#serial 9
 
 AC_DEFUN([AX_CPU_FREQ],
 [AC_REQUIRE([AC_PROG_CC])
  AC_LANG_PUSH([C++])
  AC_CACHE_CHECK(your cpu frequency, ax_cpu_freq,
  [AC_RUN_IFELSE([AC_LANG_PROGRAM([
+#include <cstring>
 #include <iostream>
-#include <sys/time.h>
 #include <fstream>
+#include <unistd.h>
+#include <sys/time.h>
 using namespace std;
 
 static __inline__ unsigned long long int rdtsc()

--- a/m4/ax_func_memmove.m4
+++ b/m4/ax_func_memmove.m4
@@ -20,7 +20,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_FUNC_MEMMOVE], [AX_FUNC_MEMMOVE])
 AC_DEFUN([AX_FUNC_MEMMOVE],
@@ -28,6 +28,8 @@ AC_DEFUN([AX_FUNC_MEMMOVE],
 AC_MSG_CHECKING(for working memmove)
 AC_CACHE_VAL(ac_cv_have_working_memmove,
 [AC_RUN_IFELSE([AC_LANG_SOURCE([[#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 int main(void)
 {

--- a/m4/ax_func_snprintf.m4
+++ b/m4/ax_func_snprintf.m4
@@ -24,7 +24,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AC_FUNC_SNPRINTF], [AX_FUNC_SNPRINTF])
 AC_DEFUN([AX_FUNC_SNPRINTF],
@@ -32,7 +32,8 @@ AC_DEFUN([AX_FUNC_SNPRINTF],
 AC_MSG_CHECKING(for working snprintf)
 AC_CACHE_VAL(ac_cv_have_working_snprintf,
 [AC_RUN_IFELSE([AC_LANG_SOURCE([[#include <stdio.h>
-
+#include <stdlib.h>
+#include <string.h>
 int main(void)
 {
     char bufs[5] = { 'x', 'x', 'x', '\0', '\0' };
@@ -51,6 +52,8 @@ AC_MSG_CHECKING(for working vsnprintf)
 AC_CACHE_VAL(ac_cv_have_working_vsnprintf,
 [AC_RUN_IFELSE([AC_LANG_SOURCE([[#include <stdio.h>
 #include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
 
 int my_vsnprintf (char *buf, const char *tmpl, ...)
 {


### PR DESCRIPTION
Clang 16 makes -Wimplicit-function-declaration an error by default.

Signed-off-by: Sam James <sam@gentoo.org>