### PR TITLE
Update python macros for PEP 632

### DIFF
--- a/m4/ax_python.m4
+++ b/m4/ax_python.m4
@@ -50,7 +50,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 20
+#serial 21
 
 AC_DEFUN([AX_PYTHON],
 [AC_MSG_CHECKING(for python build information)
@@ -64,7 +64,12 @@ if test x$ax_python_bin != x; then
      AC_CHECK_LIB(${ax_python_bin}m, main, ax_python_lib=${ax_python_bin}m, ax_python_lib=no)
    fi
    if test x$ax_python_lib != xno; then
-     ax_python_header=`$ax_python_bin -c "from distutils.sysconfig import *; print(get_config_var('CONFINCLUDEPY'))"`
+     $ax_python_bin -c 'import sysconfig' 2>&1
+     if test $? -eq 0; then
+       ax_python_header=$($ax_python_bin -c "from sysconfig import get_config_var; print(get_config_var('CONFINCLUDEPY'))")
+     else
+       ax_python_header=$($ax_python_bin -c "from distutils.sysconfig import get_config_var; print(get_config_var('CONFINCLUDEPY'))")
+     fi
      if test x$ax_python_header != x; then
        break;
      fi

--- a/m4/ax_python_config_var.m4
+++ b/m4/ax_python_config_var.m4
@@ -12,9 +12,9 @@
 #
 #   AX_PYTHON_CONFIG_VAR:
 #
-#   Using the Python module distutils.sysconfig[1], return a Python
-#   configuration variable. PYTHON_VARIABLE is the name of the variable to
-#   request from Python, and SHELL_VARIABLE is the name of the shell
+#   Using the Python module sysconfig[1] or distutils.sysconfig[2], return a
+#   Python configuration variable. PYTHON_VARIABLE is the name of the variable
+#   to request from Python, and SHELL_VARIABLE is the name of the shell
 #   variable into which the results should be deposited. If SHELL_VARIABLE
 #   is not specified, the macro wil prefix PY_ to the PYTHON_VARIABLE, e.g.,
 #   LIBS -> PY_LIBS.
@@ -29,20 +29,22 @@
 #
 #   AX_PYTHON_CONFIG_H:
 #
-#   Using the Python module distutils.sysconfig[1], put the full pathname of
-#   the config.h file used to compile Python into the shell variable
+#   Using the Python module sysconfig[1] or distutils.sysconfig[2], put the full
+#   pathname of the config.h file used to compile Python into the shell variable
 #   PY_CONFIG_H. PY_CONFIG_H is AC_SUBST'd. Note if $PYTHON is not set,
 #   AC_CHECK_PROG(PYTHON, python, python) will be run.
 #
 #   AX_PYTHON_MAKEFILE:
 #
-#   Using the Python module distutils.sysconfig[1], put the full pathname of
-#   the Makefile file used to compile Python into the shell variable
+#   Using the Python module sysconfig[1] or distutils.sysconfig[2], put the full
+#   pathname of the Makefile file used to compile Python into the shell variable
 #   PY_MAKEFILE. PY_MAKEFILE is AC_SUBST'd. Note if $PYTHON is not set,
 #   AC_CHECK_PROG(PYTHON, python, python) will be run.
 #
 #   [1]
-#   http://www.python.org/doc/current/dist/module-distutils.sysconfig.html
+#   https://docs.python.org/3/library/sysconfig.html
+#   [2]
+#   https://docs.python.org/2/distutils/apiref.html#module-distutils.sysconfig
 #
 # LICENSE
 #
@@ -53,7 +55,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 10
+#serial 11
 
 AC_DEFUN([AX_PYTHON_CONFIG_VAR],
 [
@@ -63,8 +65,12 @@ AC_DEFUN([AX_PYTHON_CONFIG_VAR],
    AC_CHECK_PROG(PYTHON,python,python)
  fi
  py_error="no"
- pyval=`$PYTHON -c "from distutils import sysconfig;dnl
-print sysconfig.get_config_var('$1')"` || py_error="yes"
+ $PYTHON -c 'import sysconfig' 2>&1
+ if test $? -eq 0; then
+   pyval=$($PYTHON -c "from sysconfig import get_config_var; print(get_config_var('$1')")) || py_error="yes"
+ else
+   pyval=$($PYTHON -c "from distutils.sysconfig import get_config_var; print(get_config_var('$1')")) || py_error="yes"
+ fi
  if test "$py_error" = "yes"
  then
    AC_MSG_RESULT(no - an error occurred)
@@ -83,8 +89,11 @@ AC_DEFUN([AX_PYTHON_CONFIG_H],
    AC_CHECK_PROG(PYTHON,python,python)
  fi
  py_error="no"
- PY_CONFIG_H=`$PYTHON -c "from distutils import sysconfig;dnl
-print sysconfig.get_config_h_filename()"` || py_error = "yes"
+ $PYTHON -c 'import sysconfig' 2>&1
+ if test $? -eq 0; then
+   PY_CONFIG_H=$($PYTHON -c "from sysconfig import get_config_h_filename; print get_config_h_filename()") || py_error="yes"
+ else
+   PY_CONFIG_H=$($PYTHON -c "from distutils.sysconfig import get_config_h_filename; print get_config_h_filename()") || py_error="yes"
  if test "$py_error" = "yes"
  then
    AC_MSG_RESULT(no - an error occurred)
@@ -102,8 +111,11 @@ AC_DEFUN([AX_PYTHON_MAKEFILE],
    AC_CHECK_PROG(PYTHON,python,python)
  fi
  py_error="no"
- PY_MAKEFILE=`$PYTHON -c "from distutils import sysconfig;dnl
-print sysconfig.get_makefile_filename()"` || py_error = "yes"
+ $PYTHON -c 'import sysconfig' 2>&1
+ if test $? -eq 0; then
+   PY_MAKEFILE=$($PYTHON -c "from sysconfig import get_makefile_filename; print get_makefile_filename()") || py_error="yes"
+ else
+   PY_MAKEFILE=$($PYTHON -c "from distutils.sysconfig import get_makefile_filename; print get_makefile_filename()") || py_error="yes"
  if test "$py_error" = "yes"
  then
    AC_MSG_RESULT(no - an error occurred)

--- a/m4/ax_python_devel.m4
+++ b/m4/ax_python_devel.m4
@@ -160,7 +160,7 @@ variable to configure. See ``configure --help'' for reference.
 	# Check if you have distutils, else fail
 	#
 	AC_MSG_CHECKING([for the sysconfig Python package])
-	ac_sysconfig_result=`$PYTHON -c "import sysconfig" 2>&1`
+	$PYTHON -c 'import sysconfig' 2>&1
 	if test $? -eq 0; then
 		AC_MSG_RESULT([yes])
 		IMPORT_SYSCONFIG="import sysconfig"
@@ -168,7 +168,7 @@ variable to configure. See ``configure --help'' for reference.
 		AC_MSG_RESULT([no])
 
 		AC_MSG_CHECKING([for the distutils Python package])
-		ac_sysconfig_result=`$PYTHON -c "from distutils import sysconfig" 2>&1`
+		$PYTHON -c 'from distutils import sysconfig' 2>&1
 		if test $? -eq 0; then
 			AC_MSG_RESULT([yes])
 			IMPORT_SYSCONFIG="from distutils import sysconfig"

--- a/m4/ax_python_module_version.m4
+++ b/m4/ax_python_module_version.m4
@@ -14,6 +14,12 @@
 #   The third parameter can either be "python" for Python 2 or "python3" for
 #   Python 3; defaults to Python 3.
 #
+#   If setuptools is installed, use packaging which is a dependency of
+#   setuptools. Otherwise for legacy python use distutils.[1]
+#
+#   [1]
+#   https://peps.python.org/pep-0632/
+#
 # LICENSE
 #
 #   Copyright (c) 2015 Endless Mobile, Inc.; contributed by Philip Chimento <philip@endlessm.com> and Kurt von Laven <kurt@endlessm.com>
@@ -23,12 +29,17 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 3
+#serial 4
 
 AC_DEFUN([AX_PYTHON_MODULE_VERSION], [
     AX_PYTHON_MODULE([$1], [required], [$3])
     AC_MSG_CHECKING([for version $2 or higher of $1])
-    $PYTHON -c "import sys, $1; from distutils.version import StrictVersion; sys.exit(StrictVersion($1.__version__) < StrictVersion('$2'))" 2> /dev/null
+    $PYTHON -c 'import packaging' 2>&1
+    if test $? -eq 0; then
+      $PYTHON -c "import sys, $1; from packaging.version import Version; sys.exit(Version($1.__version__) < Version('$2'))" 2> /dev/null
+    else
+      $PYTHON -c "import sys, $1; from distutils.version import StrictVersion; sys.exit(StrictVersion($1.__version__) < StrictVersion('$2'))" 2> /dev/null
+    fi
     AS_IF([test $? -eq 0], [], [
         AC_MSG_RESULT([no])
         AC_MSG_ERROR([You need at least version $2 of the $1 Python module.])


### PR DESCRIPTION
PEP 632 deprecates usage of distutils as of python >= 3.10.
Try to use syconfig or packaging instead. Fallback to distutils for legacy
python versions.

Bonus fix:
`ax_python_version` in `AX_PYTHON_CSPEC` didn't properly parse versions like
`python3.10`. It would have returned `3.1`.

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>