### PR TITLE
Fix ax_python_devel serial 32 fails with current python3

### DIFF
--- a/m4/ax_python_devel.m4
+++ b/m4/ax_python_devel.m4
@@ -125,7 +125,7 @@ class VPy:
         return tuple(map(int, s.strip().replace("rc", ".").split(".")))
     def __init__(self):
         import sys
-        self.vpy = tuple(sys.version_info)
+        self.vpy = tuple(sys.version_info)[[:3]]
     def __eq__(self, s):
         return self.vpy == self.vtup(s)
     def __ne__(self, s):


### PR DESCRIPTION
The faulty code was introduce in commit df89f6cdaade38f3c1c9987be0c5a57c96fc1730 https://github.com/autoconf-archive/autoconf-archive/commit/df89f6cdaade38f3c1c9987be0c5a57c96fc1730

The current code tuple(sys.version_info) gives the 5-tuple (3, 10, 7, 'final', 0) while the former code sys.version.split()[0] would give the 3-tuple (3, 10, 7). So, at first glance, the current code tuple(sys.version_info) should be replaced by tuple(sys.version_info)[:3].

A patch that applied to the current ax_python_devel serial 32 is attached.