### PR TITLE
AC_BLAS: Fix vecLib detection on modern MacOS

### DIFF
--- a/m4/ax_blas.m4
+++ b/m4/ax_blas.m4
@@ -175,9 +175,9 @@ fi
 
 # BLAS in Apple vecLib library?
 if test $ax_blas_ok = no; then
-	save_LIBS="$LIBS"; LIBS="-framework vecLib $LIBS"
-	AC_MSG_CHECKING([for $sgemm in -framework vecLib])
-	AC_LINK_IFELSE([AC_LANG_CALL([], [$sgemm])], [ax_blas_ok=yes;BLAS_LIBS="-framework vecLib"])
+	save_LIBS="$LIBS"; LIBS="-framework Accelerate $LIBS"
+	AC_MSG_CHECKING([for $sgemm in -framework Accelerate])
+	AC_LINK_IFELSE([AC_LANG_CALL([], [$sgemm])], [ax_blas_ok=yes;BLAS_LIBS="-framework Accelerate"])
 	AC_MSG_RESULT($ax_blas_ok)
 	LIBS="$save_LIBS"
 fi


### PR DESCRIPTION
For whatever reason Apple's hardened runtime scoping disallows third-party linking to -framework vecLib. Linking -framework Accelerate solves this issue.

Example output on MacOS 13.3 without patch:

```
configure:6677: checking for sgemm_ in -framework vecLib
configure:6701: clang++ -mmacosx-version-min=10.13 -std=gnu++14 -o conftest -Wall -g -O2 -I/usr/local/include  conftest.cpp -framework vecLib  -L/usr/local/opt/gcc/lib >&5
ld: cannot link directly with dylib/framework, your binary is not an allowed client of /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks//vecLib.framework/vecLib.tbd for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
configure:6701: $? = 1
```

Example output on MacOS 13.3 with patch:

```
configure:6677: checking for sgemm_ in -framework Accelerate
configure:6701: clang++ -mmacosx-version-min=10.13 -std=gnu++14 -o conftest -Wall -g -O2 -I/usr/local/include  conftest.cpp -framework Accelerate  -L/usr/local/opt/gcc/lib >&5
configure:6701: $? = 0
configure:6707: result: yes
```