### PR TITLE
Fix various typos

### DIFF
--- a/m4/ax_boost_base.m4
+++ b/m4/ax_boost_base.m4
@@ -10,7 +10,7 @@
 #
 #   Test for the Boost C++ libraries of a particular version (or newer)
 #
-#   If no path to the installed boost library is given the macro searchs
+#   If no path to the installed boost library is given the macro searches
 #   under /usr, /usr/local, /opt, /opt/local and /opt/homebrew and evaluates
 #   the $BOOST_ROOT environment variable. Further documentation is available
 #   at <http://randspringer.de/boost/index.html>.

--- a/m4/ax_cc_attrcommon.m4
+++ b/m4/ax_cc_attrcommon.m4
@@ -8,7 +8,7 @@
 #
 # DESCRIPTION
 #
-#   Determine whether the C compiler supports C tentative defintions with
+#   Determine whether the C compiler supports C tentative definitions with
 #   __attribute((__common__)) See K&R book Appendix A10.2 on 'extern' and
 #   tentative definitions. Some compilers use a 'strict definition-reference
 #   model' Traditionally most UNIX C compilers support C tentative

--- a/m4/ax_cc_tentdef.m4
+++ b/m4/ax_cc_tentdef.m4
@@ -8,7 +8,7 @@
 #
 # DESCRIPTION
 #
-#   Determine whether the C compiler supports C tentative defintions. See
+#   Determine whether the C compiler supports C tentative definitions. See
 #   K&R book Appendix A10.2 on 'extern' and tentative definitions. Some
 #   compilers use a 'strict definition-reference model' Traditionally most
 #   UNIX C compilers support tentative definitions, whereas some compiler

--- a/m4/ax_check_java_plugin.m4
+++ b/m4/ax_check_java_plugin.m4
@@ -66,7 +66,7 @@ case "x$ZIPINFO" in
 [*/pkzipc)]
 	ziping="unzipc -view";;
 [x*)]
-	AC_MSG_RESULT([skiped, none of zipinfo, unzip and pkzipc found])
+	AC_MSG_RESULT([skipped, none of zipinfo, unzip and pkzipc found])
 	AC_SUBST($1,[])
 	zipinf="";;
 esac

--- a/m4/ax_cvs.m4
+++ b/m4/ax_cvs.m4
@@ -359,7 +359,7 @@ cvs-add:
 branch-major:
 	@tag=\"\$(PACKAGE)-${AX_MAJOR_VERSION}\"; \\
 	echo \"\"; \\
-	echo \"Creating major brach: ${AX_DOLLAR}${AX_DOLLAR}tag\"; \\
+	echo \"Creating major branch: ${AX_DOLLAR}${AX_DOLLAR}tag\"; \\
 	(cd \"${AX_DOLLAR}(top_srcdir)\"; \$(CVS) tag -b \"${AX_DOLLAR}${AX_DOLLAR}tag\"; ); \\
 	\$(GAWK) -f ax_cvs_rel.awk -v change=1 \"${AX_DOLLAR}(top_srcdir)/configure.ac\" > configure.tmp; \\
 	touch ${AX_DOLLAR}(top_builddir)/commitlog; \\
@@ -389,7 +389,7 @@ branch-major:
 branch-minor:
 	@tag=\"\$(PACKAGE)-${AX_MAJOR_VERSION}_${AX_MINOR_VERSION}\"; \\
 	echo \"\"; \\
-	echo \"Creating minor brach: ${AX_DOLLAR}${AX_DOLLAR}tag\"; \\
+	echo \"Creating minor branch: ${AX_DOLLAR}${AX_DOLLAR}tag\"; \\
 	(cd \"${AX_DOLLAR}(top_srcdir)\"; \$(CVS) tag -b \"${AX_DOLLAR}${AX_DOLLAR}tag\"; ); \\
 	\$(GAWK) -f ax_cvs_rel.awk -v change=1 \"${AX_DOLLAR}(top_srcdir)/configure.ac\" > configure.tmp; \\
 	touch ${AX_DOLLAR}(top_builddir)/commitlog; \\

--- a/m4/ax_ext_have_lib.m4
+++ b/m4/ax_ext_have_lib.m4
@@ -13,7 +13,7 @@
 #   each directory.
 #
 #   Any required -L<directory> flags are added to LDFLAGS and located
-#   libraies are added to LIBS
+#   libraries are added to LIBS
 #
 #   Some libraries are unlinkable without other extra libraries, which can
 #   be specified in the 4th argument. The mysql client library needs -lz,

--- a/m4/ax_ms_cpprest.m4
+++ b/m4/ax_ms_cpprest.m4
@@ -11,7 +11,7 @@
 #   Test for the Microsoft C++ Rest SDK library of a particular version (or
 #   newer)
 #
-#   If no path to the installed cpprest library is given the macro searchs
+#   If no path to the installed cpprest library is given the macro searches
 #   under /usr, /usr/local, /opt and /opt/local and evaluates the
 #   $CPPREST_ROOT environment variable.
 #

--- a/m4/ax_path_bdb.m4
+++ b/m4/ax_path_bdb.m4
@@ -406,7 +406,7 @@ AC_DEFUN([_AX_PATH_BDB_ENV_GET_VERSION_HEADER],[
   _AX_PATH_BDB_ENV_GET_VERSION_HEADER_VERSION_HEADER_VERSION=''
   # Indicate status of checking for Berkeley DB library.
   AC_MSG_CHECKING([for db.h])
-  # could not cache compile manualy
+  # could not cache compile manually
   AC_COMPILE_IFELSE([
     AC_LANG_SOURCE([[
 #include <db.h>

--- a/m4/ax_pkg_mico.m4
+++ b/m4/ax_pkg_mico.m4
@@ -32,7 +32,7 @@
 #
 #   It defines the symbol MICOSETUP, MICOVERSION, MICOSHAREDDIR
 #   MICO_INCLUDE, MICO_LIB and MICO_CXX if mico is found. In addition, the
-#   mico script mico-c++ (set in (MICO_CXX) is scaned for a string match
+#   mico script mico-c++ (set in (MICO_CXX) is scanned for a string match
 #   "-I.*ministl" and if foundMICO_USE_MINISTL is set to 1, otherwise to 0.
 #
 #   Example of use of these variables in your Makefile.in:

--- a/m4/ax_python_config_var.m4
+++ b/m4/ax_python_config_var.m4
@@ -16,7 +16,7 @@
 #   configuration variable. PYTHON_VARIABLE is the name of the variable to
 #   request from Python, and SHELL_VARIABLE is the name of the shell
 #   variable into which the results should be deposited. If SHELL_VARIABLE
-#   is not specified, the macro wil prefix PY_ to the PYTHON_VARIABLE, e.g.,
+#   is not specified, the macro will prefix PY_ to the PYTHON_VARIABLE, e.g.,
 #   LIBS -> PY_LIBS.
 #
 #   SHELL_VARIABLE is AC_SUBST'd. No action is taken if an error occurs.


### PR DESCRIPTION
A typo checker in our project caught some typos in some macros.  Fixed those and few others that were found.

