### PR TITLE
ax_add_fortify_source.m4: fix 2nd probe

### DIFF
--- a/m4/ax_add_fortify_source.m4
+++ b/m4/ax_add_fortify_source.m4
@@ -36,7 +36,7 @@
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 8
+#serial 9
 
 AC_DEFUN([AX_ADD_FORTIFY_SOURCE],[
     ac_save_cflags=$CFLAGS
@@ -71,13 +71,11 @@ AC_DEFUN([AX_ADD_FORTIFY_SOURCE],[
               CPPFLAGS="$CPPFLAGS -D_FORTIFY_SOURCE=3"
             ], [
               AC_MSG_RESULT([no])
-              CFLAGS=$ac_save_cflags
               ax_add_fortify_3_failed=1
             ],
         ),
         [
           AC_MSG_RESULT([no])
-          CFLAGS=$ac_save_cflags
           ax_add_fortify_3_failed=1
         ])
     if test -n "$ax_add_fortify_3_failed"


### PR DESCRIPTION
it didnt error anymore, just warned.
thus without -O it still enabled the 2nd variant