### PR TITLE
Make macros `-Wstrict-prototypes` compatible

### DIFF
--- a/m4/ax_add_fortify_source.m4
+++ b/m4/ax_add_fortify_source.m4
@@ -36,7 +36,7 @@
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 9
+#serial 10
 
 AC_DEFUN([AX_ADD_FORTIFY_SOURCE],[
     ac_save_cflags=$CFLAGS
@@ -58,7 +58,7 @@ AC_DEFUN([AX_ADD_FORTIFY_SOURCE],[
             AC_LANG_SOURCE([[
                 #define _FORTIFY_SOURCE 3
                 #include <string.h>
-                int main() {
+                int main(void) {
                     char *s = " ";
                     strcpy(s, "x");
                     return strlen(s)-1;

--- a/m4/ax_c_declare_block.m4
+++ b/m4/ax_c_declare_block.m4
@@ -22,7 +22,7 @@
 #    #define ___ DECLARE_BLOCK
 #    #define ____ DECLARE_END
 #
-#    int f() {
+#    int f(void) {
 #     char buffer[1024];
 #     fgets(buffer, 1024, stdin);
 #     ___ int i; int ii = strlen(buffer);
@@ -61,14 +61,16 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 11
+#serial 12
 
 AC_DEFUN([AX_C_DECLARE_BLOCK],[dnl
 AC_CACHE_CHECK(
  [if C variables must be declared at the beginning of a block],
  ax_cv_c_declare_block,[
- AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <stdio.h>
- int f() {
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[dnl
+ #include <stdio.h>
+ #include <string.h>
+ int f(void) {
    char buffer[1024];
    fgets(buffer, 1024, stdin);
    int i; int ii = strlen(buffer);

--- a/m4/ax_c_restrict.m4
+++ b/m4/ax_c_restrict.m4
@@ -24,7 +24,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 2
+#serial 3
 
 AC_DEFUN([AX_C_RESTRICT],
 [AC_CACHE_CHECK([for restrict usability],
@@ -39,7 +39,7 @@ AC_DEFUN([AX_C_RESTRICT],
     	    copy (&b[i & 1], &a[i & 1]);
     	}
     }
-    int main () {
+    int main (void) {
     	int ary[] = {0, 1, 2};
     	test (&ary[1], &ary[0]);
     	/* printf("%d %d %d\n", ary[0], ary[1], ary[2]);

--- a/m4/ax_cc_tentdef.m4
+++ b/m4/ax_cc_tentdef.m4
@@ -36,7 +36,7 @@
 #   You should have received a copy of the GNU General Public License along
 #   with this program. If not, see <https://www.gnu.org/licenses/>.
 
-#serial 4
+#serial 5
 
 AC_ARG_WITH(tentdef,
   [  --with-tentdef          use C tentative definitions],
@@ -64,7 +64,7 @@ EOF
 cat >$t2 <<EOF
 #include <stdio.h>
 int a;
-int main() { exit(a);return a; }
+int main(void) { exit(a);return a; }
 EOF
 
 echo "$CC $t1 $t2 -o $e1" >&5

--- a/m4/ax_check_define.m4
+++ b/m4/ax_check_define.m4
@@ -23,7 +23,7 @@
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 11
+#serial 12
 
 AU_ALIAS([AC_CHECK_DEFINED], [AC_CHECK_DEFINE])
 AC_DEFUN([AC_CHECK_DEFINE],[
@@ -63,8 +63,8 @@ AC_CACHE_CHECK([for $2], ac_var,
 dnl AC_LANG_FUNC_LINK_TRY
 [AC_LINK_IFELSE([AC_LANG_PROGRAM([$1
                 #undef $2
-                char $2 ();],[
-                char (*f) () = $2;
+                char $2 (void);],[
+                char (*f) (void) = $2;
                 return f != $2; ])],
                 [AS_VAR_SET(ac_var, yes)],
                 [AS_VAR_SET(ac_var, no)])])

--- a/m4/ax_check_page_aligned_malloc.m4
+++ b/m4/ax_check_page_aligned_malloc.m4
@@ -36,7 +36,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 11
+#serial 12
 
 AC_DEFUN([AX_CHECK_PAGE_ALIGNED_MALLOC],
 [AC_CACHE_CHECK([if large mallocs guarantee page-alignment],
@@ -48,7 +48,7 @@ AC_DEFUN([AX_CHECK_PAGE_ALIGNED_MALLOC],
 # include <unistd.h>
 #endif
 
-int main()
+int main(void)
 {
   int pagesize = getpagesize();
   int i;

--- a/m4/ax_check_strftime.m4
+++ b/m4/ax_check_strftime.m4
@@ -19,7 +19,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 8
+#serial 9
 
 AU_ALIAS([AG_CHECK_STRFTIME], [AX_CHECK_STRFTIME])
 AC_DEFUN([AX_CHECK_STRFTIME],[
@@ -28,7 +28,7 @@ AC_DEFUN([AX_CHECK_STRFTIME],[
   AC_RUN_IFELSE([AC_LANG_SOURCE([[#include <time.h>
 #include <string.h>
 char t_buf[ 64 ];
-int main() {
+int main(void) {
   static const char z[] = "Thursday Aug 28 240";
   struct tm tm;
   tm.tm_sec   = 36;  /* seconds after the minute [0, 61]  */

--- a/m4/ax_check_sys_siglist.m4
+++ b/m4/ax_check_sys_siglist.m4
@@ -19,14 +19,14 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AU_ALIAS([AG_CHECK_SYS_SIGLIST], [AX_CHECK_SYS_SIGLIST])
 AC_DEFUN([AX_CHECK_SYS_SIGLIST],[
   AC_MSG_CHECKING([whether there is a global text array sys_siglist])
   AC_CACHE_VAL([ax_cv_sys_siglist],[
   AC_RUN_IFELSE([AC_LANG_SOURCE([[#include <signal.h>
-int main() {
+int main(void) {
   const char* pz = sys_siglist[1];
   return (pz != 0) ? 0 : 1; }]])],[ax_cv_sys_siglist=yes],[ax_cv_sys_siglist=no],[ax_cv_sys_siglist=no]
   ) # end of TRY_RUN]) # end of CACHE_VAL

--- a/m4/ax_cpu_freq.m4
+++ b/m4/ax_cpu_freq.m4
@@ -19,7 +19,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 9
+#serial 10
 
 AC_DEFUN([AX_CPU_FREQ],
 [AC_REQUIRE([AC_PROG_CC])
@@ -33,7 +33,7 @@ AC_DEFUN([AX_CPU_FREQ],
 #include <sys/time.h>
 using namespace std;
 
-static __inline__ unsigned long long int rdtsc()
+static __inline__ unsigned long long int rdtsc(void)
 {
   unsigned long long int x;
   __asm__ volatile (".byte 0x0f, 0x31":"=A" (x));

--- a/m4/ax_ext.m4
+++ b/m4/ax_ext.m4
@@ -44,7 +44,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 18
+#serial 19
 
 AC_DEFUN([AX_EXT],
 [
@@ -167,7 +167,7 @@ AC_DEFUN([AX_EXT],
                control registers directly. Execute an SSE instruction.
                If it raises SIGILL then OS doesn't support SSE based instructions */
             void sig_handler(int signum){ exit(1); }
-            int main(){
+            int main(void){
               signal(SIGILL, sig_handler);
               /* SSE instruction xorps  %xmm0,%xmm0 */
               __asm__ __volatile__ (".byte 0x0f, 0x57, 0xc0");

--- a/m4/ax_func_posix_memalign.m4
+++ b/m4/ax_func_posix_memalign.m4
@@ -22,7 +22,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 9
+#serial 10
 
 AC_DEFUN([AX_FUNC_POSIX_MEMALIGN],
 [AC_CACHE_CHECK([for working posix_memalign],
@@ -31,7 +31,7 @@ AC_DEFUN([AX_FUNC_POSIX_MEMALIGN],
 #include <stdlib.h>
 
 int
-main ()
+main (void)
 {
   void *buffer;
 

--- a/m4/ax_have_select.m4
+++ b/m4/ax_have_select.m4
@@ -40,8 +40,12 @@ AC_DEFUN([AX_HAVE_SELECT], [dnl
   AC_CACHE_VAL([ax_cv_have_select], [dnl
     AC_LINK_IFELSE([dnl
       AC_LANG_PROGRAM(
-        [#include <sys/select.h>],
-        [int rc; rc = select(0, (fd_set *)(0), (fd_set *)(0), (fd_set *)(0), (struct timeval *)(0));])],
+        [[dnl
+#include <sys/select.h>
+#include <sys/time.h>]],
+        [[dnl
+int rc;
+rc = select(0, (fd_set *)(0), (fd_set *)(0), (fd_set *)(0), (struct timeval *)(0));]])],
       [ax_cv_have_select=yes],
       [ax_cv_have_select=no])])
   AS_IF([test "${ax_cv_have_select}" = "yes"],
@@ -55,13 +59,15 @@ AC_DEFUN([AX_HAVE_PSELECT], [dnl
   AC_CACHE_VAL([ax_cv_have_pselect], [dnl
     AC_LINK_IFELSE([dnl
       AC_LANG_PROGRAM(
-        [dnl
+        [[dnl
 #include <sys/select.h>
-#include <signal.h>],
-        [dnl
+#include <sys/time.h>
+#include <signal.h>
+#include <time.h>]],
+        [[dnl
 int rc;
 rc = select(0, (fd_set *)(0), (fd_set *)(0), (fd_set *)(0), (struct timeval *)(0));
-rc = pselect(0, (fd_set *)(0), (fd_set *)(0), (fd_set *)(0), (struct timespec const *)(0), (sigset_t const *)(0));])],
+rc = pselect(0, (fd_set *)(0), (fd_set *)(0), (fd_set *)(0), (struct timespec const *)(0), (sigset_t const *)(0));]])],
       [ax_cv_have_pselect=yes],
       [ax_cv_have_pselect=no])])
   AS_IF([test "${ax_cv_have_pselect}" = "yes"],

--- a/m4/ax_openmp.m4
+++ b/m4/ax_openmp.m4
@@ -67,7 +67,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 13
+#serial 14
 
 AC_DEFUN([AX_OPENMP], [
 AC_PREREQ([2.69]) dnl for _AC_LANG_PREFIX
@@ -101,7 +101,7 @@ parallel_fill(int * data, int n)
 }
 
 int
-main()
+main(void)
 {
   int arr[100000];
   omp_set_num_threads(2);

--- a/m4/ax_sys_weak_alias.m4
+++ b/m4/ax_sys_weak_alias.m4
@@ -110,7 +110,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 8
+#serial 9
 
 AU_ALIAS([KLM_SYS_WEAK_ALIAS], [AX_SYS_WEAK_ALIAS])
 AC_DEFUN([AX_SYS_WEAK_ALIAS], [
@@ -294,7 +294,7 @@ _ACEOF
 
 extern void weakf(int c);
 int
-main ()
+main (void)
 {
   weakf(0);
   return 0;


### PR DESCRIPTION
* With Clang having switched to modern C conventions already and GCC following suit soon, we want to have macros that work in the presence of `-Wstrict-prototypes` in all C language modes, not just C23.