### PR TITLE
ax_prototype: Disable "unused variable" warning

### DIFF
--- a/m4/ax_prototype.m4
+++ b/m4/ax_prototype.m4
@@ -114,7 +114,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 10
+#serial 11
 
 AU_ALIAS([AC_PROTOTYPE], [AX_PROTOTYPE])
 AC_DEFUN([AX_PROTOTYPE],[
@@ -219,8 +219,13 @@ dnl
      ac_save_CPPFLAGS="$CPPFLAGS"
 dnl     ifelse(AC_LANG,CPLUSPLUS,if test "$GXX" = "yes" ; then CPPFLAGS="$CPPFLAGS -Werror" ; fi)
 dnl     ifelse(AC_LANG,C,if test "$GCC" = "yes" ; then CPPFLAGS="$CPPFLAGS -Werror" ; fi)
-dnl     TODO: consider the compiler check from ax_cflags_warn_all.m4
-        if (test "x$GCC" = "xyes" || test "x$GXX" = "xyes" ); then CPPFLAGS="$CPPFLAGS -Werror" ; fi
+dnl
+dnl Disable the 'unused-variable' warning in case e.g. -Wall was enabled,
+dnl otherwise the test may always fail.
+dnl
+        if (test "x$GCC" = "xyes" || test "x$GXX" = "xyes" ); then
+          CPPFLAGS="$CPPFLAGS -Werror -Wno-unused-variable" ;
+        fi
 
      AC_COMPILE_IFELSE([AC_LANG_PROGRAM([$2], [$1])],
      [


### PR DESCRIPTION
The `unused-variable` warning must be explicitly disabled to prevent accidental failures when the user has e.g. enabled `-Wall` (which enables `unused-variable`), since the macro uses `-Werror` to check the result.
Without disabling the warning, all prototype tests will fail with GCC because the code creates a variable to check the function type and then doesn't use it. This results in what looks like no prototypes matched while in fact one could match, but was rejected due to implicit or explicit `-Wunused-variable` together with `-Werror` (in other words, was rejected, but not by the warning/error that was meant to be used by the macro as the main criterion).
Tested, works for me.