### PR TITLE
Add Lua 5.4 support to AX_PROG_LUA macro

### DIFF
--- a/m4/ax_lua.m4
+++ b/m4/ax_lua.m4
@@ -19,7 +19,7 @@
 #   header is checked to match the Lua interpreter version exactly. When
 #   searching for Lua libraries, the version number is used as a suffix.
 #   This is done with the goal of supporting multiple Lua installs (5.1,
-#   5.2, and 5.3 side-by-side).
+#   5.2, 5.3, and 5.4 side-by-side).
 #
 #   A note on compatibility with previous versions: This file has been
 #   mostly rewritten for serial 18. Most developers should be able to use
@@ -181,7 +181,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 43
+#serial 44
 
 dnl =========================================================================
 dnl AX_PROG_LUA([MINIMUM-VERSION], [TOO-BIG-VERSION],
@@ -198,7 +198,7 @@ AC_DEFUN([AX_PROG_LUA],
 
   dnl Find a Lua interpreter.
   m4_define_default([_AX_LUA_INTERPRETER_LIST],
-    [lua lua5.3 lua53 lua5.2 lua52 lua5.1 lua51 lua50])
+    [lua lua5.4 lua54 lua5.3 lua53 lua5.2 lua52 lua5.1 lua51 lua50])
 
   m4_if([$1], [],
   [ dnl No version check is needed. Find any Lua interpreter.

--- a/m4/ax_lua.m4
+++ b/m4/ax_lua.m4
@@ -181,7 +181,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 42
+#serial 43
 
 dnl =========================================================================
 dnl AX_PROG_LUA([MINIMUM-VERSION], [TOO-BIG-VERSION],
@@ -268,7 +268,7 @@ AC_DEFUN([AX_PROG_LUA],
         ax_cv_lua_version=[`$LUA -e '
           -- return a version number in X.Y format
           local _, _, ver = string.find(_VERSION, "^Lua (%d+%.%d+)")
-          print(ver)'`]
+          print(ver or "")'`]
       ])
     AS_IF([test "x$ax_cv_lua_version" = 'x'],
       [AC_MSG_ERROR([invalid Lua version number])])


### PR DESCRIPTION
Since the current Lua version is 5.4, many distros package it with a bare `lua` binary and suffix older builds with the version number. This is *not* universally true however, nor is it forward-compatible. On systems where there is either no default Lua or the default Lua is set to an older version, searching for the binary with the version suffix is the only way to find the newest one. This should be done in priority to falling back to older versions for consistency.