### PR TITLE
Fix typos found by codespell

### DIFF
--- a/doc/autoconf-archive.texi
+++ b/doc/autoconf-archive.texi
@@ -11,7 +11,7 @@
 
 @copying
 This manual is for GNU Autoconf Archive version @value{VERSION}, a collection of
-freely re-usable Autoconf macros.
+freely reusable Autoconf macros.
 
 Copyright @copyright{} 2022 Autoconf Archive Maintainers
 @email{autoconf-archive-maintainers@@gnu.org}
@@ -26,7 +26,7 @@ Documentation License''.
 
 @dircategory Software development
 @direntry
-* Autoconf Archive: (autoconf-archive). A collection of re-usable Autoconf macros.
+* Autoconf Archive: (autoconf-archive). A collection of reusable Autoconf macros.
 @end direntry
 
 @titlepage

--- a/m4/ax_check_glu.m4
+++ b/m4/ax_check_glu.m4
@@ -49,7 +49,7 @@
 #   framework.
 #
 #   Some implementations (in particular, some versions of Mac OS X) are
-#   known to treat the GLU tesselator callback function type as "GLvoid
+#   known to treat the GLU tessellator callback function type as "GLvoid
 #   (*)(...)" rather than the standard "GLvoid (*)()". If the former
 #   condition is detected, this macro defines "HAVE_VARARGS_GLU_TESSCB".
 #
@@ -85,7 +85,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 23
+#serial 24
 
 # example program
 m4_define([_AX_CHECK_GLU_PROGRAM],
@@ -116,7 +116,7 @@ AC_DEFUN([_AX_CHECK_GLU_INCLUDES_DEFAULT],dnl
   ]
 ])
 
-# check tesselation callback function signature.
+# check tessellation callback function signature.
 m4_define([_AX_CHECK_GLU_VARARGS_TESSVB_PROGRAM],
 [AC_LANG_PROGRAM([[
 # if defined(HAVE_WINDOWS_H) && defined(_WIN32)
@@ -254,9 +254,9 @@ AC_DEFUN([AX_CHECK_GLU],[
 
 #
 # Some versions of Mac OS X include a broken interpretation of the GLU
-# tesselation callback function signature.
+# tessellation callback function signature.
   AS_IF([test "X$ax_cv_check_glu_link" = "Xyes"],
-        [AC_CACHE_CHECK([if GLU varargs tesselator is using non-standard form],
+        [AC_CACHE_CHECK([if GLU varargs tessellator is using non-standard form],
                         [ax_cv_varargs_glu_tesscb],
                         [_AX_CHECK_GLU_SAVE_FLAGS([CFLAGS],[C++])
                          AC_COMPILE_IFELSE([_AX_CHECK_GLU_VARARGS_TESSVB_PROGRAM],
@@ -265,7 +265,7 @@ AC_DEFUN([AX_CHECK_GLU],[
                          _AX_CHECK_GLU_RESTORE_FLAGS([CFLAGS],[C++])])
         AS_IF([test "X$ax_cv_varargs_glu_tesscb" = "yes"],
               [AC_DEFINE([HAVE_VARARGS_GLU_TESSCB], [1],
-                         [Use nonstandard varargs form for the GLU tesselator callback])])
+                         [Use nonstandard varargs form for the GLU tessellator callback])])
         ])
 
   dnl hook

--- a/m4/ax_cpu_freq.m4
+++ b/m4/ax_cpu_freq.m4
@@ -19,7 +19,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 10
+#serial 11
 
 AC_DEFUN([AX_CPU_FREQ],
 [AC_REQUIRE([AC_PROG_CC])
@@ -88,7 +88,7 @@ static float average_MHz(int tries = 2)
     of.close()
 ])],
      [ax_cpu_freq=`cat conftest_cpufreq`; rm -f conftest_cpufreq],
-     [ax_cpu_freq=unknow; rm -f conftest_cpufreq]
+     [ax_cpu_freq=unknown; rm -f conftest_cpufreq]
  )])
 AC_LANG_POP([C++])
 

--- a/m4/ax_dist_msi.m4
+++ b/m4/ax_dist_msi.m4
@@ -53,7 +53,7 @@ if test "x$MSI_SETUP_FILE" != "x"; then
 		  AC_MSG_NOTICE([dist-msi support enabled]))
 else
     AC_MSG_NOTICE([setting msi file... not set])
-    AC_MSG_ERROR([a file must be specified when addind msi support])
+    AC_MSG_ERROR([a file must be specified when adding msi support])
 fi
 AM_CONDITIONAL([ax_dist_msi_enabled],[test "x$USING_DIST_MSI" = "xtrue"])
 AX_ADD_AM_MACRO_STATIC([

--- a/m4/ax_lua.m4
+++ b/m4/ax_lua.m4
@@ -82,7 +82,7 @@
 #   appropriate Automake primary, e.g. lua_SCRIPS or luaexec_LIBRARIES.
 #
 #   If an acceptable Lua interpreter is found, then ACTION-IF-FOUND is
-#   performed, otherwise ACTION-IF-NOT-FOUND is preformed. If ACTION-IF-NOT-
+#   performed, otherwise ACTION-IF-NOT-FOUND is performed. If ACTION-IF-NOT-
 #   FOUND is blank, then it will default to printing an error. To prevent
 #   the default behavior, give ':' as an action.
 #
@@ -181,7 +181,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 44
+#serial 45
 
 dnl =========================================================================
 dnl AX_PROG_LUA([MINIMUM-VERSION], [TOO-BIG-VERSION],

--- a/m4/ax_prog_cc_for_build.m4
+++ b/m4/ax_prog_cc_for_build.m4
@@ -32,7 +32,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 21
+#serial 22
 
 AU_ALIAS([AC_PROG_CC_FOR_BUILD], [AX_PROG_CC_FOR_BUILD])
 AC_DEFUN([AX_PROG_CC_FOR_BUILD], [dnl
@@ -141,7 +141,7 @@ popdef([ac_cv_prog_gcc])dnl
 popdef([ac_cv_prog_CPP])dnl
 
 dnl restore global variables ac_ext, ac_cpp, ac_compile,
-dnl ac_link, ac_compiler_gnu (dependant on the current
+dnl ac_link, ac_compiler_gnu (dependent on the current
 dnl language after popping):
 AC_LANG_POP([C])
 

--- a/m4/ax_prog_cxx_for_build.m4
+++ b/m4/ax_prog_cxx_for_build.m4
@@ -31,7 +31,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 4
+#serial 5
 
 AU_ALIAS([AC_PROG_CXX_FOR_BUILD], [AX_PROG_CXX_FOR_BUILD])
 AC_DEFUN([AX_PROG_CXX_FOR_BUILD], [dnl
@@ -103,7 +103,7 @@ popdef([ac_cv_prog_cxx_works])dnl
 popdef([ac_cv_prog_gxx])dnl
 popdef([ac_cv_prog_CXXCPP])dnl
 
-dnl restore global variables (dependant on the current
+dnl restore global variables (dependent on the current
 dnl language after popping):
 AC_LANG_POP([C++])
 

--- a/m4/ax_prog_tcl.m4
+++ b/m4/ax_prog_tcl.m4
@@ -55,7 +55,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 8
+#serial 9
 
 AC_DEFUN([AX_PROG_TCL], [
 #-- check for tclsh in PATH
@@ -67,7 +67,7 @@ fi
 #-- check for wish in PATH
 AC_PATH_PROG([WISH], [wish], [no])
 
-#-- check vor tcl version
+#-- check for tcl version
 AC_MSG_CHECKING([tcl version])
 version=`echo "puts [[set tcl_version]]" | tclsh -`
 AC_MSG_RESULT([$version])

--- a/m4/ax_sys_perlsharpbang.m4
+++ b/m4/ax_sys_perlsharpbang.m4
@@ -20,7 +20,7 @@
 #
 #     --with-perl-shebang='#! /my/funky/perlpath' # OR
 #     --with-perl-shebang='/my/funky/perlpath'  # we just throw away the #! anyway
-#                                               # bec it must be absent in Makefile
+#                                               # as it must not appear in Makefile
 #
 #   Rationale: The are various ways of starting an interpreter on different
 #   *nix-like systems. Many use the simple

--- a/m4/ax_try_awk_anyout.m4
+++ b/m4/ax_try_awk_anyout.m4
@@ -9,7 +9,7 @@
 # DESCRIPTION
 #
 #   Run a test using the awk program found on AWK variable. The test being
-#   run has TEST-BODY as body and is feeded with TEST-INPUT. If successful
+#   run has TEST-BODY as body and is fed with TEST-INPUT. If successful
 #   execute ACTION-IF-SUCCESS otherwise ACTION-IF-FAILURE
 #
 #   This work is heavily based upon testawk.sh script by Heiner Steven. You
@@ -27,7 +27,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 9
+#serial 10
 
 AC_DEFUN([AX_TRY_AWK_ANYOUT], [
   AC_REQUIRE([AX_NEED_AWK])

--- a/m4/ax_try_awk_expout.m4
+++ b/m4/ax_try_awk_expout.m4
@@ -9,7 +9,7 @@
 # DESCRIPTION
 #
 #   Run a test using the awk program found on AWK variable. The test being
-#   run has TEST-BODY as body and is feeded with TEST-INPUT. Check if the
+#   run has TEST-BODY as body and is fed with TEST-INPUT. Check if the
 #   test gives the expected output. If successful execute ACTION-IF-SUCCESS
 #   otherwise ACTION-IF-FAILURE.
 #
@@ -28,7 +28,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 9
+#serial 10
 
 AC_DEFUN([AX_TRY_AWK_EXPOUT], [
   AC_REQUIRE([AX_NEED_AWK])


### PR DESCRIPTION
* Both `re-usable` and `reusable` can be seen as correct, but:
  * Majors dictionaries suggest `reuse` only:
    * [OED](https://www.oed.com/search/dictionary/?q=re-use)
    * [Cambridge](https://www.oxfordlearnersdictionaries.com/definition/english/reuse_1)
    * [Collins](https://www.collinsdictionary.com/dictionary/english/reuse)
    * [Longman](https://www.ldoceonline.com/dictionary/reuse)
    * [Merriam-Webster](https://www.merriam-webster.com/dictionary/reuse)
    * [Oxford Learner's Dictionary](https://dictionary.cambridge.org/dictionary/english/reuse)
  * From [The Blue Book of Grammar and Punctuation](https://www.grammarbook.com/blog/hyphens/hyphens-with-the-prefix-re/):
    > Use the hyphen with the prefix _re_ only when _re_ means _again_ AND omitting the hyphen would cause confusion with another word.
* Both `tesselation` and `tessellation` can be seen as correct, but:
  * The [Google Ngram Viewer](https://books.google.com/ngrams/graph?content=tesselation%2Ctessellation&year_start=1800&year_end=2019&corpus=en-2019) shows `tessellation`  has been in much wider use.
  * The [GLU Library](http://archive.irixnet.org/siliconsurf/tech/openGL/mjk.intro/subsection3_2_6.html) documentation uses `tessellation`