### PR TITLE
AX_PROG_CC_FOR_BUILD patches that fix BUILD_{EXE,OBJ}EXT (Autoconf 2.70)

### DIFF
--- a/m4/ax_prog_cc_for_build.m4
+++ b/m4/ax_prog_cc_for_build.m4
@@ -32,7 +32,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 25
+#serial 26
 
 AU_ALIAS([AC_PROG_CC_FOR_BUILD], [AX_PROG_CC_FOR_BUILD])
 AC_DEFUN([AX_PROG_CC_FOR_BUILD], [dnl
@@ -47,9 +47,12 @@ pushdef([ac_cv_prog_gcc], ac_cv_build_prog_gcc)dnl
 pushdef([ac_cv_prog_cc_c89], ac_cv_build_prog_cc_c89)dnl
 pushdef([ac_cv_prog_cc_c99], ac_cv_build_prog_cc_c99)dnl
 pushdef([ac_cv_prog_cc_c11], ac_cv_build_prog_cc_c11)dnl
+pushdef([ac_cv_prog_cc_c23], ac_cv_build_prog_cc_c23)dnl
+pushdef([ac_cv_prog_cc_stdc], ac_cv_build_prog_cc_stdc)dnl
 pushdef([ac_cv_prog_cc_works], ac_cv_build_prog_cc_works)dnl
 pushdef([ac_cv_prog_cc_cross], ac_cv_build_prog_cc_cross)dnl
 pushdef([ac_cv_prog_cc_g], ac_cv_build_prog_cc_g)dnl
+pushdef([ac_prog_cc_stdc], ac_build_prog_cc_stdc)dnl
 pushdef([ac_exeext], ac_build_exeext)dnl
 pushdef([ac_objext], ac_build_objext)dnl
 pushdef([CC], CC_FOR_BUILD)dnl
@@ -138,9 +141,12 @@ popdef([CPP])dnl
 popdef([CC])dnl
 popdef([ac_objext])dnl
 popdef([ac_exeext])dnl
+popdef([ac_prog_cc_stdc])dnl
 popdef([ac_cv_prog_cc_g])dnl
 popdef([ac_cv_prog_cc_cross])dnl
 popdef([ac_cv_prog_cc_works])dnl
+popdef([ac_cv_prog_cc_stdc])dnl
+popdef([ac_cv_prog_cc_c23])dnl
 popdef([ac_cv_prog_cc_c11])dnl
 popdef([ac_cv_prog_cc_c99])dnl
 popdef([ac_cv_prog_cc_c89])dnl

--- a/m4/ax_prog_cc_for_build.m4
+++ b/m4/ax_prog_cc_for_build.m4
@@ -32,7 +32,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 22
+#serial 23
 
 AU_ALIAS([AC_PROG_CC_FOR_BUILD], [AX_PROG_CC_FOR_BUILD])
 AC_DEFUN([AX_PROG_CC_FOR_BUILD], [dnl
@@ -51,8 +51,6 @@ pushdef([ac_cv_prog_cc_works], ac_cv_build_prog_cc_works)dnl
 pushdef([ac_cv_prog_cc_cross], ac_cv_build_prog_cc_cross)dnl
 pushdef([ac_cv_prog_cc_g], ac_cv_build_prog_cc_g)dnl
 pushdef([ac_cv_c_compiler_gnu], ac_cv_build_c_compiler_gnu)dnl
-pushdef([ac_cv_exeext], ac_cv_build_exeext)dnl
-pushdef([ac_cv_objext], ac_cv_build_objext)dnl
 pushdef([ac_exeext], ac_build_exeext)dnl
 pushdef([ac_objext], ac_build_objext)dnl
 pushdef([CC], CC_FOR_BUILD)dnl
@@ -60,9 +58,7 @@ pushdef([CPP], CPP_FOR_BUILD)dnl
 pushdef([GCC], GCC_FOR_BUILD)dnl
 pushdef([CFLAGS], CFLAGS_FOR_BUILD)dnl
 pushdef([CPPFLAGS], CPPFLAGS_FOR_BUILD)dnl
-pushdef([EXEEXT], BUILD_EXEEXT)dnl
 pushdef([LDFLAGS], LDFLAGS_FOR_BUILD)dnl
-pushdef([OBJEXT], BUILD_OBJEXT)dnl
 pushdef([host], build)dnl
 pushdef([host_alias], build_alias)dnl
 pushdef([host_cpu], build_cpu)dnl
@@ -77,6 +73,24 @@ pushdef([ac_tool_prefix], ac_build_tool_prefix)dnl
 pushdef([am_cv_CC_dependencies_compiler_type], am_cv_build_CC_dependencies_compiler_type)dnl
 pushdef([am_cv_prog_cc_c_o], am_cv_build_prog_cc_c_o)dnl
 pushdef([cross_compiling], cross_compiling_build)dnl
+dnl
+dnl These variables are problematic to rename by M4 macros, so we save
+dnl their values in alternative names, and restore the values later.
+dnl
+dnl _AC_COMPILER_EXEEXT and _AC_COMPILER_OBJEXT internally call
+dnl AC_SUBST which prevents the renaming of EXEEXT and OBJEXT
+dnl variables. It's not a good idea to rename ac_cv_exeext and
+dnl ac_cv_objext either as they're related.
+dnl Renaming ac_exeext and ac_objext is safe though.
+dnl
+ac_cv_host_exeext=$ac_cv_exeext
+AS_VAR_SET_IF([ac_cv_build_exeext],
+  [ac_cv_exeext=$ac_cv_build_exeext],
+  [AS_UNSET([ac_cv_exeext])])
+ac_cv_host_objext=$ac_cv_objext
+AS_VAR_SET_IF([ac_cv_build_objext],
+  [ac_cv_objext=$ac_cv_build_objext],
+  [AS_UNSET([ac_cv_objext])])
 
 cross_compiling_build=no
 
@@ -104,6 +118,9 @@ _AC_COMPILER_EXEEXT
 _AC_COMPILER_OBJEXT
 AC_PROG_CPP
 
+BUILD_EXEEXT=$ac_cv_exeext
+BUILD_OBJEXT=$ac_cv_objext
+
 dnl Restore the old definitions
 dnl
 popdef([cross_compiling])dnl
@@ -120,9 +137,7 @@ popdef([host_vendor])dnl
 popdef([host_cpu])dnl
 popdef([host_alias])dnl
 popdef([host])dnl
-popdef([OBJEXT])dnl
 popdef([LDFLAGS])dnl
-popdef([EXEEXT])dnl
 popdef([CPPFLAGS])dnl
 popdef([CFLAGS])dnl
 popdef([GCC])dnl
@@ -130,8 +145,6 @@ popdef([CPP])dnl
 popdef([CC])dnl
 popdef([ac_objext])dnl
 popdef([ac_exeext])dnl
-popdef([ac_cv_objext])dnl
-popdef([ac_cv_exeext])dnl
 popdef([ac_cv_c_compiler_gnu])dnl
 popdef([ac_cv_prog_cc_g])dnl
 popdef([ac_cv_prog_cc_cross])dnl
@@ -139,6 +152,11 @@ popdef([ac_cv_prog_cc_works])dnl
 popdef([ac_cv_prog_cc_c89])dnl
 popdef([ac_cv_prog_gcc])dnl
 popdef([ac_cv_prog_CPP])dnl
+dnl
+ac_cv_exeext=$ac_cv_host_exeext
+EXEEXT=$ac_cv_host_exeext
+ac_cv_objext=$ac_cv_host_objext
+OBJEXT=$ac_cv_host_objext
 
 dnl restore global variables ac_ext, ac_cpp, ac_compile,
 dnl ac_link, ac_compiler_gnu (dependent on the current
@@ -147,8 +165,8 @@ AC_LANG_POP([C])
 
 dnl Finally, set Makefile variables
 dnl
-AC_SUBST(BUILD_EXEEXT)dnl
-AC_SUBST(BUILD_OBJEXT)dnl
+AC_SUBST([BUILD_EXEEXT])dnl
+AC_SUBST([BUILD_OBJEXT])dnl
 AC_SUBST([CFLAGS_FOR_BUILD])dnl
 AC_SUBST([CPPFLAGS_FOR_BUILD])dnl
 AC_SUBST([LDFLAGS_FOR_BUILD])dnl

--- a/m4/ax_prog_cc_for_build.m4
+++ b/m4/ax_prog_cc_for_build.m4
@@ -32,7 +32,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 24
+#serial 25
 
 AU_ALIAS([AC_PROG_CC_FOR_BUILD], [AX_PROG_CC_FOR_BUILD])
 AC_DEFUN([AX_PROG_CC_FOR_BUILD], [dnl
@@ -43,10 +43,10 @@ AC_REQUIRE([AC_CANONICAL_BUILD])dnl
 dnl Use the standard macros, but make them use other variable names
 dnl
 pushdef([ac_cv_prog_CPP], ac_cv_build_prog_CPP)dnl
+pushdef([ac_cv_prog_gcc], ac_cv_build_prog_gcc)dnl
 pushdef([ac_cv_prog_cc_c89], ac_cv_build_prog_cc_c89)dnl
 pushdef([ac_cv_prog_cc_c99], ac_cv_build_prog_cc_c99)dnl
 pushdef([ac_cv_prog_cc_c11], ac_cv_build_prog_cc_c11)dnl
-pushdef([ac_cv_prog_gcc], ac_cv_build_prog_gcc)dnl
 pushdef([ac_cv_prog_cc_works], ac_cv_build_prog_cc_works)dnl
 pushdef([ac_cv_prog_cc_cross], ac_cv_build_prog_cc_cross)dnl
 pushdef([ac_cv_prog_cc_g], ac_cv_build_prog_cc_g)dnl
@@ -141,6 +141,8 @@ popdef([ac_exeext])dnl
 popdef([ac_cv_prog_cc_g])dnl
 popdef([ac_cv_prog_cc_cross])dnl
 popdef([ac_cv_prog_cc_works])dnl
+popdef([ac_cv_prog_cc_c11])dnl
+popdef([ac_cv_prog_cc_c99])dnl
 popdef([ac_cv_prog_cc_c89])dnl
 popdef([ac_cv_prog_gcc])dnl
 popdef([ac_cv_prog_CPP])dnl

--- a/m4/ax_prog_cc_for_build.m4
+++ b/m4/ax_prog_cc_for_build.m4
@@ -32,7 +32,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 23
+#serial 24
 
 AU_ALIAS([AC_PROG_CC_FOR_BUILD], [AX_PROG_CC_FOR_BUILD])
 AC_DEFUN([AX_PROG_CC_FOR_BUILD], [dnl
@@ -50,7 +50,6 @@ pushdef([ac_cv_prog_gcc], ac_cv_build_prog_gcc)dnl
 pushdef([ac_cv_prog_cc_works], ac_cv_build_prog_cc_works)dnl
 pushdef([ac_cv_prog_cc_cross], ac_cv_build_prog_cc_cross)dnl
 pushdef([ac_cv_prog_cc_g], ac_cv_build_prog_cc_g)dnl
-pushdef([ac_cv_c_compiler_gnu], ac_cv_build_c_compiler_gnu)dnl
 pushdef([ac_exeext], ac_build_exeext)dnl
 pushdef([ac_objext], ac_build_objext)dnl
 pushdef([CC], CC_FOR_BUILD)dnl
@@ -91,6 +90,14 @@ ac_cv_host_objext=$ac_cv_objext
 AS_VAR_SET_IF([ac_cv_build_objext],
   [ac_cv_objext=$ac_cv_build_objext],
   [AS_UNSET([ac_cv_objext])])
+dnl
+dnl ac_cv_c_compiler_gnu is used in _AC_LANG_COMPILER_GNU (called by
+dnl AC_PROG_CC) indirectly.
+dnl
+ac_cv_host_c_compiler_gnu=$ac_cv_c_compiler_gnu
+AS_VAR_SET_IF([ac_cv_build_c_compiler_gnu],
+  [ac_cv_c_compiler_gnu=$ac_cv_build_c_compiler_gnu],
+  [AS_UNSET([ac_cv_c_compiler_gnu])])
 
 cross_compiling_build=no
 
@@ -99,21 +106,7 @@ AS_IF([test -n "$build"],      [ac_build_tool_prefix="$build-"],
       [test -n "$build_alias"],[ac_build_tool_prefix="$build_alias-"])
 
 AC_LANG_PUSH([C])
-
-dnl The pushdef([ac_cv_c_compiler_gnu], ...) currently does not cover
-dnl the use of this variable in _AC_LANG_COMPILER_GNU called by
-dnl AC_PROG_CC. Unset this cache variable temporarily as a workaround.
-was_set_c_compiler_gnu=${[ac_cv_c_compiler_gnu]+y}
-AS_IF([test ${was_set_c_compiler_gnu}],
-    [saved_c_compiler_gnu=$[ac_cv_c_compiler_gnu]
-    AS_UNSET([[ac_cv_c_compiler_gnu]])])
-
 AC_PROG_CC
-
-dnl Restore ac_cv_c_compiler_gnu
-AS_IF([test ${was_set_c_compiler_gnu}],
-  [[ac_cv_c_compiler_gnu]=$[saved_c_compiler_gnu]])
-
 _AC_COMPILER_EXEEXT
 _AC_COMPILER_OBJEXT
 AC_PROG_CPP
@@ -145,7 +138,6 @@ popdef([CPP])dnl
 popdef([CC])dnl
 popdef([ac_objext])dnl
 popdef([ac_exeext])dnl
-popdef([ac_cv_c_compiler_gnu])dnl
 popdef([ac_cv_prog_cc_g])dnl
 popdef([ac_cv_prog_cc_cross])dnl
 popdef([ac_cv_prog_cc_works])dnl
@@ -157,6 +149,8 @@ ac_cv_exeext=$ac_cv_host_exeext
 EXEEXT=$ac_cv_host_exeext
 ac_cv_objext=$ac_cv_host_objext
 OBJEXT=$ac_cv_host_objext
+ac_cv_c_compiler_gnu=$ac_cv_host_c_compiler_gnu
+ac_compiler_gnu=$ac_cv_host_c_compiler_gnu
 
 dnl restore global variables ac_ext, ac_cpp, ac_compile,
 dnl ac_link, ac_compiler_gnu (dependent on the current


### PR DESCRIPTION
This pull request is a mirror of [patch #10452](https://savannah.gnu.org/patch/index.php?10452).

The BUILD_EXEEXT and BUILD_OBJEXT variables in AX_PROG_CC_FOR_BUILD are broken again in Autoconf 2.70 and later.

This patchset fixes compatibility problems found in Autoconf 2.70 and later.

* Make `BUILD_EXEEXT` and `BUILD_OBJEXT` work again.
* Tweak the previous workaround of `ac_cv_c_compiler_gnu` code and make the solution permanent. The users should now be able to override the `ac_cv_build_c_compiler_gnu` cache variable.
* Fix regression where the `ac_cv_prog_cc_c99` and `ac_cv_prog_cc_c11` macros
are not popped after the `AX_PROG_CC_FOR_BUILD` call.
* Support `ac_build_prog_cc_stdc` (Autoconf 2.70) and `ac_cv_build_prog_cc_c23` (Autoconf 2.73).

