### PR TITLE
Fix AC_CACHE_VAL warning

### DIFF
--- a/m4/ax_cpu_freq.m4
+++ b/m4/ax_cpu_freq.m4
@@ -19,12 +19,12 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 11
+#serial 12
 
 AC_DEFUN([AX_CPU_FREQ],
 [AC_REQUIRE([AC_PROG_CC])
  AC_LANG_PUSH([C++])
- AC_CACHE_CHECK(your cpu frequency, ax_cpu_freq,
+ AC_CACHE_CHECK([your cpu frequency], [ax_cv_cpu_freq],
  [AC_RUN_IFELSE([AC_LANG_PROGRAM([
 #include <cstring>
 #include <iostream>
@@ -87,10 +87,13 @@ static float average_MHz(int tries = 2)
 
     of.close()
 ])],
-     [ax_cpu_freq=`cat conftest_cpufreq`; rm -f conftest_cpufreq],
-     [ax_cpu_freq=unknown; rm -f conftest_cpufreq]
+     [ax_cv_cpu_freq=`cat conftest_cpufreq`],
+     [ax_cv_cpu_freq=unknown],
+     [ax_cv_cpu_freq=unknown]
  )])
 AC_LANG_POP([C++])
 
-  AC_DEFINE_UNQUOTED([CPU_FREQ], ${ax_cpu_freq}, [The cpu frequency (in MHz)])
+AS_VAR_IF([ax_cv_cpu_freq], [unknown],,
+  [AC_DEFINE_UNQUOTED([CPU_FREQ], [${ax_cv_cpu_freq}],
+    [The cpu frequency (in MHz)])])
 ])


### PR DESCRIPTION
Cache variables must contain `_cv_` to be cached otherwise this warning is emitted when generating configure script:

    AC_CACHE_VAL(ax_cpu_freq, ...): suspicious cache-id, must contain _cv_
    to be cached

I'll wait with this one for the existing PR #292 to be merged first