### PR TITLE
ax_code_coverage: remove /tmp/* from remove patterns failing with lcov 2.0

### DIFF
--- a/m4/ax_code_coverage.m4
+++ b/m4/ax_code_coverage.m4
@@ -144,7 +144,7 @@ code_coverage_v_lcov_cap_ = \$(code_coverage_v_lcov_cap_\$(AM_DEFAULT_VERBOSITY)
 code_coverage_v_lcov_cap_0 = @echo \"  LCOV   --capture\" \$(CODE_COVERAGE_OUTPUT_FILE);
 code_coverage_v_lcov_ign = \$(code_coverage_v_lcov_ign_\$(V))
 code_coverage_v_lcov_ign_ = \$(code_coverage_v_lcov_ign_\$(AM_DEFAULT_VERBOSITY))
-code_coverage_v_lcov_ign_0 = @echo \"  LCOV   --remove /tmp/*\" \$(CODE_COVERAGE_IGNORE_PATTERN);
+code_coverage_v_lcov_ign_0 = @echo \"  LCOV   --remove\" \"\$(CODE_COVERAGE_OUTPUT_FILE).tmp\" \$(CODE_COVERAGE_IGNORE_PATTERN);
 code_coverage_v_genhtml = \$(code_coverage_v_genhtml_\$(V))
 code_coverage_v_genhtml_ = \$(code_coverage_v_genhtml_\$(AM_DEFAULT_VERBOSITY))
 code_coverage_v_genhtml_0 = @echo \"  GEN   \" \"\$(CODE_COVERAGE_OUTPUT_DIRECTORY)\";
@@ -163,7 +163,7 @@ check-code-coverage:
 # Capture code coverage data
 code-coverage-capture: code-coverage-capture-hook
 	\$(code_coverage_v_lcov_cap)\$(LCOV) \$(code_coverage_quiet) \$(addprefix --directory ,\$(CODE_COVERAGE_DIRECTORY)) --capture --output-file \"\$(CODE_COVERAGE_OUTPUT_FILE).tmp\" --test-name \"\$(call code_coverage_sanitize,\$(PACKAGE_NAME)-\$(PACKAGE_VERSION))\" --no-checksum --compat-libtool \$(CODE_COVERAGE_LCOV_SHOPTS) \$(CODE_COVERAGE_LCOV_OPTIONS)
-	\$(code_coverage_v_lcov_ign)\$(LCOV) \$(code_coverage_quiet) \$(addprefix --directory ,\$(CODE_COVERAGE_DIRECTORY)) --remove \"\$(CODE_COVERAGE_OUTPUT_FILE).tmp\" \"/tmp/*\" \$(CODE_COVERAGE_IGNORE_PATTERN) --output-file \"\$(CODE_COVERAGE_OUTPUT_FILE)\" \$(CODE_COVERAGE_LCOV_SHOPTS) \$(CODE_COVERAGE_LCOV_RMOPTS)
+	\$(code_coverage_v_lcov_ign)\$(LCOV) \$(code_coverage_quiet) \$(addprefix --directory ,\$(CODE_COVERAGE_DIRECTORY)) --remove \"\$(CODE_COVERAGE_OUTPUT_FILE).tmp\" \$(CODE_COVERAGE_IGNORE_PATTERN) --output-file \"\$(CODE_COVERAGE_OUTPUT_FILE)\" \$(CODE_COVERAGE_LCOV_SHOPTS) \$(CODE_COVERAGE_LCOV_RMOPTS)
 	-@rm -f \"\$(CODE_COVERAGE_OUTPUT_FILE).tmp\"
 	\$(code_coverage_v_genhtml)LANG=C \$(GENHTML) \$(code_coverage_quiet) \$(addprefix --prefix ,\$(CODE_COVERAGE_DIRECTORY)) --output-directory \"\$(CODE_COVERAGE_OUTPUT_DIRECTORY)\" --title \"\$(PACKAGE_NAME)-\$(PACKAGE_VERSION) Code Coverage\" --legend --show-details \"\$(CODE_COVERAGE_OUTPUT_FILE)\" \$(CODE_COVERAGE_GENHTML_OPTIONS)
 	@echo \"file://\$(abs_builddir)/\$(CODE_COVERAGE_OUTPUT_DIRECTORY)/index.html\"


### PR DESCRIPTION
The lcov >= 2.0 refactored error handling and by default it fails when an unused remove pattern is provided:

  LCOV   --remove /tmp/* */tests/*.c
lcov: ERROR: 'exclude' pattern '/tmp/*' is unused.
        (use "lcov --ignore-errors unused ..." to bypass this error)

Based on the macro history is is not clear why the /tmp/* would be needed by default. Usual autotools projects don't use /tmp/. If needed users can still add this pattern to
CODE_COVERAGE_IGNORE_PATTERN.

This can be reproduced for example in Fedora 40 which comes with lcov 2.0:

```
docker run --rm -it fedora:40                                                  
                                                                               
dnf install -y gcc automake autoconf gawk lcov gcovr git autoconf-archive      
                                                                               
git clone https://github.com/janzizazizka/autotools-template.git               
cd autotools-template                                                          
git checkout dd8ecefd9de42305e9b7914c6b3bd01d2c0a3021                          
                                                                               
./autogen.sh                                                                   
./configure --enable-code-coverage                                             
make check-code-coverage
```

Results with:

```
  LCOV   --remove /tmp/* */tests/*.c
lcov: ERROR: 'exclude' pattern '/tmp/*' is unused.
        (use "lcov --ignore-errors unused ..." to bypass this error)
```

Or does anyone know why we should have `/tmp/*` by default in remove pattern?