### PR TITLE
AX_BOOST_BASE: Don't set BOOST_*FLAGS if Boost is not found

### DIFF
--- a/m4/ax_boost_base.m4
+++ b/m4/ax_boost_base.m4
@@ -33,7 +33,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 54
+#serial 55
 
 # example boost program (need to pass version)
 m4_define([_AX_BOOST_BASE_PROGRAM],
@@ -289,6 +289,8 @@ AC_DEFUN([_AX_BOOST_BASE_RUNDETECT],[
         else
             AC_MSG_NOTICE([Your boost libraries seems to old (version $_version).])
         fi
+        BOOST_LDFLAGS=""
+        BOOST_CPPFLAGS=""
         # execute ACTION-IF-NOT-FOUND (if present):
         ifelse([$3], , :, [$3])
     else


### PR DESCRIPTION
Previously BOOST_CPPFLAGS was set to a nonsensical -I/include/boost-0 value if Boost headers were not found at all and BOOST_LDFLAGS was similarly set to a wrong (although less obviously so) value in this case because they kept the last values tested by the macro.

Just don't set these variables at all if detecting Boost failed.