### PR TITLE
Use AS_VAR_IF in ax_gcc_builtin.m4

### DIFF
--- a/m4/ax_gcc_builtin.m4
+++ b/m4/ax_gcc_builtin.m4
@@ -94,7 +94,7 @@
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 7
+#serial 8
 
 AC_DEFUN([AX_GCC_BUILTIN], [
     AS_VAR_PUSHDEF([ac_var], [ax_cv_have_$1])
@@ -168,7 +168,7 @@ AC_DEFUN([AX_GCC_BUILTIN], [
             [AS_VAR_SET([ac_var], [no])])
     ])
 
-    AS_IF([test yes = AS_VAR_GET([ac_var])],
+    AS_VAR_IF([ac_var], [yes],
         [AC_DEFINE_UNQUOTED(AS_TR_CPP(HAVE_$1), 1,
             [Define to 1 if the system has the `$1' built-in function])], [])
 


### PR DESCRIPTION
The AS_VAR_IF check can be a simpler alternative to testing for variable value inside AS_IF.