### PR TITLE
Validate macro arguments at autoconf compile time

### DIFF
--- a/m4/ax_check_gl.m4
+++ b/m4/ax_check_gl.m4
@@ -85,7 +85,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 22
+#serial 23
 
 # example gl program
 m4_define([_AX_CHECK_GL_PROGRAM],
@@ -187,8 +187,7 @@ AC_DEFUN([_AX_CHECK_GL_LINK_CV],
 AC_DEFUN([_AX_CHECK_GL_MANUAL_LIBS_GENERIC], [
   AS_IF([test -n "$GL_LIBS"],[], [
     ax_check_gl_manual_libs_generic_extra_libs="$1"
-    AS_IF([test "X$ax_check_gl_manual_libs_generic_extra_libs" = "X"],
-          [AC_MSG_ERROR([AX_CHECK_GL_MANUAL_LIBS_GENERIC argument must no be empty])])
+    m4_if($1, [], m4_fatal([$0: argument must not be empty]))
 
     _AX_CHECK_GL_SAVE_FLAGS([CFLAGS])
     AC_SEARCH_LIBS([glBegin],[$ax_check_gl_manual_libs_generic_extra_libs], [

--- a/m4/ax_check_glx.m4
+++ b/m4/ax_check_glx.m4
@@ -61,7 +61,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 8
+#serial 9
 
 # example program
 m4_define([_AX_CHECK_GLX_PROGRAM],
@@ -183,8 +183,7 @@ AC_DEFUN([_AX_CHECK_GLX_HEADERS],
 AC_DEFUN([_AX_CHECK_GLX_MANUAL_LIBS_GENERIC],
 [dnl
  ax_check_glx_manual_libs_generic_extra_libs="$1"
- AS_IF([test "X$ax_check_glx_manual_libs_generic_extra_libs" = "X"],
-       [AC_MSG_ERROR([AX_CHECK_GLX_MANUAL_LIBS_GENERIC argument must no be empty])])
+ m4_if($1, [], m4_fatal([$0: argument must not be empty]))
 
  AC_LANG_PUSH([C])
  _AX_CHECK_GLX_SAVE_FLAGS()

--- a/m4/ax_is_release.m4
+++ b/m4/ax_is_release.m4
@@ -45,7 +45,7 @@
 #   permitted in any medium without royalty provided the copyright notice
 #   and this notice are preserved.
 
-#serial 8
+#serial 9
 
 AC_DEFUN([AX_IS_RELEASE],[
     AC_BEFORE([AC_INIT],[$0])
@@ -76,6 +76,6 @@ AC_DEFUN([AX_IS_RELEASE],[
       [always],[ax_is_release=yes],
       [never],[ax_is_release=no],
       [
-        AC_MSG_ERROR([Invalid policy. Valid policies: git-directory, minor-version, micro-version, dash-version, always, never.])
+        m4_if($1, [], m4_fatal([$0: invalid policy $1. Valid policies: git-directory, minor-version, micro-version, dash-version, always, never]))
       ])
 ])

--- a/m4/ax_switch_flags.m4
+++ b/m4/ax_switch_flags.m4
@@ -36,12 +36,12 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 4
+#serial 5
 
 AC_DEFUN([AX_SWITCH_FLAGS], [
+  m4_if($1, [], m4_fatal([$0: namespace is empty]))
   AC_REQUIRE(AX_SAVE_FLAGS)
   AC_REQUIRE(AX_RESTORE_FLAGS)
-  AS_IF([test "X$1" = "X"], AC_MSG_ERROR(newnamespace is empty)]
   AX_SAVE_FLAGS($1[])
   AX_RESTORE_FLAGS($2[])
 ])


### PR DESCRIPTION
While debugging something else I noticed some macros had debugging code designed to emit a `./configure` error if the configure.ac invocation of the macro is malformed. I updated the macros a bit using m4sugar, so that now they error out when running autoconf, and include a stacktrace of where in configure.ac or *.m4 the error occurred. This should be much easier to analyze than possibly creating a broken dist tarball, then having an end user fail to run ./configure and get an error that doesn't even help to pinpoint which configure.ac code has the issue.