### PR TITLE
Suppress warning in zlib macro

### DIFF
--- a/m4/ax_check_zlib.m4
+++ b/m4/ax_check_zlib.m4
@@ -118,8 +118,6 @@ then
     # If both library and header were found, action-if-found
     #
     m4_ifblank([$1],[
-                CPPFLAGS="$CPPFLAGS -I${ZLIB_HOME}/include"
-                LDFLAGS="$LDFLAGS -L${ZLIB_HOME}/lib"
                 LIBS="-lz $LIBS"
                 AC_DEFINE([HAVE_LIBZ], [1],
                           [Define to 1 if you have `z' library (-lz)])


### PR DESCRIPTION
Hi,

I've recently noticed a bunch of warnings like the following
```
ld: warning: search path '/lib' not found
```
on a Mac when using `ax_check_zlib.m4`. Looking into this, it seems this is because `ZLIB_HOME` is not set on my system and so a non-existing path is being added to `LDFLAGS` in L122. It looks to me like  L121-2 should not be there anyway, since they would have already been added in L108-9 which has a protection against `ZLIB_HOME` not being set. 🤔 