### PR TITLE
Typo: ziping → zipinf

### DIFF
--- a/m4/ax_check_java_plugin.m4
+++ b/m4/ax_check_java_plugin.m4
@@ -64,7 +64,7 @@ case "x$ZIPINFO" in
 [*/unzip)]
 	zipinf="unzip -l";;
 [*/pkzipc)]
-	ziping="unzipc -view";;
+	zipinf="unzipc -view";;
 [x*)]
 	AC_MSG_RESULT([skipped, none of zipinfo, unzip and pkzipc found])
 	AC_SUBST($1,[])


### PR DESCRIPTION
I may be missing something, but `zipinf` is used everywhere else, so `ziping` looks like an error.