### PR TITLE
ax_cxx_compile_stdcxx: Fix consecutive testing of older standard versions.

### DIFF
--- a/m4/ax_cxx_compile_stdcxx.m4
+++ b/m4/ax_cxx_compile_stdcxx.m4
@@ -44,7 +44,7 @@
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 24
+#serial 25
 
 dnl  This macro is based on the code from the AX_CXX_COMPILE_STDCXX_11 macro
 dnl  (serial version number 13).
@@ -167,35 +167,25 @@ m4_define([_AX_CXX_COMPILE_STDCXX_testbody_11],
 dnl  Test body for checking C++14 support
 
 m4_define([_AX_CXX_COMPILE_STDCXX_testbody_14],
-  [_AX_CXX_COMPILE_STDCXX_testbody_new_in_11
-   _AX_CXX_COMPILE_STDCXX_testbody_new_in_14]
+  [_AX_CXX_COMPILE_STDCXX_testbody_new_in_14]
 )
 
 dnl  Test body for checking C++17 support
 
 m4_define([_AX_CXX_COMPILE_STDCXX_testbody_17],
-  [_AX_CXX_COMPILE_STDCXX_testbody_new_in_11
-   _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
-   _AX_CXX_COMPILE_STDCXX_testbody_new_in_17]
+  [_AX_CXX_COMPILE_STDCXX_testbody_new_in_17]
 )
 
 dnl  Test body for checking C++20 support
 
 m4_define([_AX_CXX_COMPILE_STDCXX_testbody_20],
-  [_AX_CXX_COMPILE_STDCXX_testbody_new_in_11
-   _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
-   _AX_CXX_COMPILE_STDCXX_testbody_new_in_17
-   _AX_CXX_COMPILE_STDCXX_testbody_new_in_20]
+  [_AX_CXX_COMPILE_STDCXX_testbody_new_in_20]
 )
 
 dnl  Test body for checking C++23 support
 
 m4_define([_AX_CXX_COMPILE_STDCXX_testbody_23],
-  _AX_CXX_COMPILE_STDCXX_testbody_new_in_11
-  _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
-  _AX_CXX_COMPILE_STDCXX_testbody_new_in_17
-  _AX_CXX_COMPILE_STDCXX_testbody_new_in_20
-  _AX_CXX_COMPILE_STDCXX_testbody_new_in_23
+  [_AX_CXX_COMPILE_STDCXX_testbody_new_in_23]
 )
 
 


### PR DESCRIPTION

Testing with a compiler that supports C++20 but not C++23, the following snippet
```
AX_CXX_COMPILE_STDCXX(23, [noext], [optional])
AS_IF([test "x$HAVE_CXX23" != "x1"],
 AX_CXX_COMPILE_STDCXX(20, [noext], [optional])
 AS_IF([test "x$HAVE_CXX20" != "x1"],
  [
   AX_CXX_COMPILE_STDCXX(17, [noext], [mandatory])
  ],[]
 )
)
```
results in
```
checking whether g++ supports C++23 features with -std=c++23... no
checking whether g++ supports C++23 features with +std=c++23... no
checking whether g++ supports C++23 features with -h std=c++23... no
checking whether g++ supports C++23 features with -std:c++23... no
configure: No compiler with C++23 support was found
checking whether g++ supports C++20 features with -std=c++20... no
checking whether g++ supports C++20 features with +std=c++20... no
checking whether g++ supports C++20 features with -h std=c++20... no
checking whether g++ supports C++20 features with -std:c++20... no
configure: No compiler with C++20 support was found
checking whether g++ supports C++17 features with -std=c++17... no
checking whether g++ supports C++17 features with +std=c++17... no
checking whether g++ supports C++17 features with -h std=c++17... no
checking whether g++ supports C++17 features with -std:c++17... no
checking whether g++ supports C++17 features with -std=c++1z... no
checking whether g++ supports C++17 features with +std=c++1z... no
checking whether g++ supports C++17 features with -h std=c++1z... no
checking whether g++ supports C++17 features with -std:c++1z... no
configure: error: *** A compiler with support for C++17 language features is required.
```
, which is obviously not what was intended.

The intended result is

```
checking whether g++ supports C++23 features with -std=c++23... no
checking whether g++ supports C++23 features with +std=c++23... no
checking whether g++ supports C++23 features with -h std=c++23... no
checking whether g++ supports C++23 features with -std:c++23... no
configure: No compiler with C++23 support was found
checking whether g++ supports C++20 features with -std=c++20... yes
```
, which this pull request provides.

I am unsure why exactly this happens as I do not consider myself an Autoconf or m4 or shell expert. A little bit of printf-style debugging revealed that it looks like something in Autoconf caches the `AC_COMPILE_IFELSE` invocations for the individual `_AX_CXX_COMPILE_STDCXX_testbody_new_in_??` code blocks across invocations, even with different compiler flags (i.e. `_AX_CXX_COMPILE_STDCXX_testbody_new_in_20` fails to compile with `-std=c++23` because the compiler does not support C++23, and then, when checking for C++20, it does not get re-checked with `-std=c++20`). So, there might be a more Autoconf-correct-ish way to "fix" this.

However, as C++ standards are generally supersets of one another (and in cases where they are not, the user should expect that features which are removed in newer standard are actually not available when choosing such a standard version), only checking for features and/or the monotonically increasing `__cplusplus` value of the precise standard version requested, should be enough and yield identical results in all cases. It should also make the checks slightly faster because less work is done (I did not measure).

I am leaving this as a Draft right now as I would prefer some input from more Autoconf-savy people (highlighting anyone who has contributed to `ax_cxx_compile_stdcxx.m4` since roughly C++17: @krnowak @vapier @mheinzler @ngie-eign @jicama @maflcko @manxorist @ojwb @ggraham @peti). Still, I would prefer a solution to be merged rather quickly, as this is still completely preventing me from enabling C++23 with Autoconf in my project. 
