### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+TODO linguist-language=Org


### PR DESCRIPTION
Split off from #289. This addition simply helps Linguist recognize the proper file type for the TODO list.