### PR TITLE
Silence lint warnings on CI workflows

### DIFF
--- a/.github/workflows/autoconf-archive.yml
+++ b/.github/workflows/autoconf-archive.yml
@@ -1,22 +1,23 @@
+---
 name: cooljeanius/autoconf-archive
 on:
   push:
     branches:
-    - "**/*"
+      - "**/*"
   pull_request:
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - name: checkout
-      uses: actions/checkout@v3.5.0
-      with:
-        fetch-depth: 50000
-    - run: sudo apt-get update        
-    - run: sudo apt-get -y install gnulib python3 texlive texinfo tidy
-    - run: "./bootstrap.sh"
-    - run: "./configure"
-    - run: make PYTHON=python3 -j$(nproc) maintainer-all all
-    - run: make distcheck
-    - run: make web-manual
-    - run: "./fix-website.sh"
+      - name: checkout
+        uses: actions/checkout@v3.5.0
+        with:
+          fetch-depth: 50000
+      - run: sudo apt-get update
+      - run: sudo apt-get -y install gnulib python3 texlive texinfo tidy
+      - run: "./bootstrap.sh"
+      - run: "./configure"
+      - run: make PYTHON=python3 -j"$(nproc)" maintainer-all all
+      - run: make distcheck
+      - run: make web-manual
+      - run: "./fix-website.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
+---
 # .travis.yml
 
 language: c
+os: linux
+dist: jammy
 git:
   depth: 50000
 


### PR DESCRIPTION
This is just the CI workflows portion of #289 that can be merged independently from the rest of it; I'm leaving out the parts that depend on the added targets or other changes to the build system made in that PR.