### PR TITLE
AX_CXX_COMPILE_STDCXX: Add missing quoting

### DIFF
--- a/m4/ax_cxx_compile_stdcxx.m4
+++ b/m4/ax_cxx_compile_stdcxx.m4
@@ -44,7 +44,7 @@
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 24
+#serial 25
 
 dnl  This macro is based on the code from the AX_CXX_COMPILE_STDCXX_11 macro
 dnl  (serial version number 13).
@@ -191,11 +191,11 @@ m4_define([_AX_CXX_COMPILE_STDCXX_testbody_20],
 dnl  Test body for checking C++23 support
 
 m4_define([_AX_CXX_COMPILE_STDCXX_testbody_23],
-  _AX_CXX_COMPILE_STDCXX_testbody_new_in_11
-  _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
-  _AX_CXX_COMPILE_STDCXX_testbody_new_in_17
-  _AX_CXX_COMPILE_STDCXX_testbody_new_in_20
-  _AX_CXX_COMPILE_STDCXX_testbody_new_in_23
+  [_AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_17
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_20
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_23]
 )
 
 


### PR DESCRIPTION
5b0d43b767bf3f800f97892905b6d1ba50150f1a added quoting to the definitions of _AX_CXX_COMPILE_STDCXX_testbody_11, etc but _AX_CXX_COMPILE_STDCXX_testbody_23 was missed.  I haven't found a situation in which this quoting actually makes a difference, but it does seem more correct to quote here and it really should be done consistently for all the _AX_CXX_COMPILE_STDCXX_testbody_* definitions.

See #308