### PR TITLE
AX_C_FLOAT_WORDS_BIGENDIAN: fix bug with Emscripten target

### DIFF
--- a/m4/ax_c_float_words_bigendian.m4
+++ b/m4/ax_c_float_words_bigendian.m4
@@ -77,7 +77,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 13
+#serial 14
 
 AC_DEFUN([AX_C_FLOAT_WORDS_BIGENDIAN],
   [AC_CACHE_CHECK(whether float word ordering is bigendian,
@@ -98,10 +98,10 @@ int main (int argc, char *argv[])
 
 ]])], [
 
-if grep noonsees conftest$EXEEXT >/dev/null ; then
+if grep noonsees conftest* >/dev/null ; then
   ax_cv_c_float_words_bigendian=yes
 fi
-if grep seesnoon conftest$EXEEXT >/dev/null ; then
+if grep seesnoon conftest* >/dev/null ; then
   if test "$ax_cv_c_float_words_bigendian" = unknown; then
     ax_cv_c_float_words_bigendian=no
   else


### PR DESCRIPTION
Commit 23be7ccd7f306fbc73b3f33e2f5ead716d120eef "Fix AX_C_FLOAT_WORDS_BIGENDIAN fails whenever interprocedural optimization is enabled." introduced a regression on the Emscripten target because it switched from grepping the object file where the float definitely will live, to grepping aclocal$EXEEXT which in the case of Emscripten will be aclocal.js but the float is in aclocal.wasm. This problem is unique to Emscripten, it is not present on any other webassembly platform.

To fix, grep `conftest*` for the float.