### PR TITLE
Don't embed build timestamp for AX_AM_MACROS*.

### DIFF
--- a/m4/ax_am_macros.m4
+++ b/m4/ax_am_macros.m4
@@ -24,7 +24,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 11
+#serial 12
 
 AC_DEFUN([AX_AM_MACROS],
 [
@@ -32,10 +32,8 @@ AC_MSG_NOTICE([adding automake macro support])
 AMINCLUDE="aminclude.am"
 AC_SUBST(AMINCLUDE)
 AC_MSG_NOTICE([creating $AMINCLUDE])
-AMINCLUDE_TIME=`LC_ALL=C date`
 AX_PRINT_TO_FILE([$AMINCLUDE],[[
 # generated automatically by configure from AX_AUTOMAKE_MACROS
-# on $AMINCLUDE_TIME
 
 ]])
 

--- a/m4/ax_am_macros_static.m4
+++ b/m4/ax_am_macros_static.m4
@@ -25,7 +25,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 11
+#serial 12
 
 AC_DEFUN([AMINCLUDE_STATIC],[aminclude_static.am])
 
@@ -33,6 +33,6 @@ AC_DEFUN([AX_AM_MACROS_STATIC],
 [
 AX_AC_PRINT_TO_FILE(AMINCLUDE_STATIC,[
 # ]AMINCLUDE_STATIC[ generated automatically by Autoconf
-# from AX_AM_MACROS_STATIC on ]m4_esyscmd([LC_ALL=C date])[
+# from AX_AM_MACROS_STATIC
 ])
 ])


### PR DESCRIPTION
Hi!

I noticed that libtasn1 source tarballs are not reproducible because AX_AM_MACROS* embed timestamps into some *.m4 files.

Would you consider removing that timestamping, as per the attached patch?

I believe adding build timestamps into generated files like this is considered poor practice, and no other autoconf/automake/libtool/gnulib etc appear to do so.

/Simon
