### PR TITLE
AX_PKG_CHECK_MODULES: Remove extra whitespace from PUBLIC-MODULES and PRIVATE-MODULES arguments

### DIFF
--- a/m4/ax_pkg_check_modules.m4
+++ b/m4/ax_pkg_check_modules.m4
@@ -50,7 +50,7 @@
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 4
+#serial 5
 
 AC_DEFUN([AX_PKG_CHECK_MODULES],[
     m4_define([ax_package_requires],
@@ -61,7 +61,7 @@ AC_DEFUN([AX_PKG_CHECK_MODULES],[
     ax_package_requires="$[]ax_package_requires m4_normalize($2)"
     ax_package_requires_private="$[]ax_package_requires_private m4_normalize($3)"
 
-    PKG_CHECK_MODULES([$1],[$2 $3],[$4],[$5])
+    PKG_CHECK_MODULES([$1],[m4_normalize($2 $3)],[$4],[$5])
 
     # Substitute output.
     AC_SUBST(ax_package_requires)


### PR DESCRIPTION
`AX_PKG_CHECK_MODULES` currently produces oddly-spaced output when `PUBLIC-MODULES` is empty but `PRIVATE-MODULES` is not.

```
AX_PKG_CHECK_MODULES([FOO], [], [foo])
```
produces `configure` output like:
```
checking for foo...  yes
```
Note the _two_ spaces between `...` and `yes`. The extra space after `...` comes from the way `AX_PKG_CHECK_MODULES` calls `PKG_CHECK_MODULES`:
```
PKG_CHECK_MODULES([$1],[$2 $3],[$4],[$5])
```
The second argument `$2 $3` ends up having a leading space when `$2` is empty.

Normalizing `$2 $3` fixes this: Use `m4_normalize($2 $3)` instead of `$2 $3`.