### PR TITLE
fix check based on pg_config

### DIFF
--- a/m4/ax_lib_postgresql.m4
+++ b/m4/ax_lib_postgresql.m4
@@ -117,7 +117,7 @@ AC_DEFUN([_AX_LIB_POSTGRESQL_PKG_CONFIG],
 	  [PKG_CHECK_EXISTS([libpq],[found_postgresql_pkg_config=yes],[found_postgresql=no])],
 	  [PKG_CHECK_EXISTS([libpq >= "$postgresql_version_req"],
 			   [found_postgresql=yes],[found_postgresql=no])])
-    AS_IF([test "X$found_postgresql" = "no"],[break])
+    AS_IF([test "X$found_postgresql" = "Xno"],[break])
 
     AC_CACHE_CHECK([for the PostgreSQL libraries CPPFLAGS],[ac_cv_POSTGRESQL_CPPFLAGS],
 		   [ac_cv_POSTGRESQL_CPPFLAGS="`$PKG_CONFIG libpq --cflags-only-I`" || _AX_LIB_POSTGRESQL_PKG_CONFIG_fail=yes])


### PR DESCRIPTION
Now, this macro doesn't work correctly for pg_config. This commit fix this bug.

When pg_config is specified, then check of libpq fails. It fails because CPPFLAGS is broken, and the CPPFLAGS is broken, because empty value is stored in cache from previous unsuccessfull checks against pkg_config.

The function _AX_LIB_POSTGRESQL_PKG_CONFIG is correctly stopped because test ` AS_IF([test "X$found_postgresql" = "no"],[break])` is broken.

Should be ` AS_IF([test "X$found_postgresql" = "Xno"],[break])`